### PR TITLE
Updated PdCore to api level 23

### DIFF
--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.puredata.android.fifths"

--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -6,13 +6,13 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "org.puredata.android.fifths"
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 3
         versionName "0.3"
     }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(':midi:AndroidMidi')
+    compile 'com.android.support:support-v4:23.1.0'
 }
 
 group = 'org.puredata.android.service'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -10,12 +10,12 @@ archivesBaseName="PdCore"
 version = '1.0'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName version
     }

--- a/PdCore/src/org/puredata/android/service/PdService.java
+++ b/PdCore/src/org/puredata/android/service/PdService.java
@@ -245,12 +245,18 @@ public class PdService extends Service {
 		protected static final int NOTIFICATION_ID = 1;
 		private boolean hasForeground = false;
 
-		@SuppressWarnings("deprecation")
 		protected Notification makeNotification(Intent intent, int icon, String title, String description) {
 			PendingIntent pi = PendingIntent.getActivity(getApplicationContext(), 0, intent, 0);
-			Notification notification = new Notification(icon, title, System.currentTimeMillis());
-			notification.setLatestEventInfo(PdService.this, title, description, pi);
-			notification.flags |= Notification.FLAG_ONGOING_EVENT;
+			Notification notification = new Notification.Builder(PdService.this)
+					.setSmallIcon(icon)
+					.setContentTitle(title)
+					.setTicker(title)
+					.setContentText(description)
+					.setOngoing(true)
+					.setContentIntent(pi)
+					.setWhen(System.currentTimeMillis())
+					.build();
+
 			return notification;
 		}
 

--- a/PdCore/src/org/puredata/android/service/PdService.java
+++ b/PdCore/src/org/puredata/android/service/PdService.java
@@ -30,6 +30,7 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 /**
@@ -247,7 +248,7 @@ public class PdService extends Service {
 
 		protected Notification makeNotification(Intent intent, int icon, String title, String description) {
 			PendingIntent pi = PendingIntent.getActivity(getApplicationContext(), 0, intent, 0);
-			Notification notification = new Notification.Builder(PdService.this)
+			Notification notification = new NotificationCompat.Builder(PdService.this)
 					.setSmallIcon(icon)
 					.setContentTitle(title)
 					.setTicker(title)

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -6,12 +6,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionCode 11
         versionName "0.9.2"
     }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -6,12 +6,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 11
         versionName "0.9.2"
     }

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -6,12 +6,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 11
         versionName "1.0"
     }

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 22
         versionCode 11
         versionName "1.0"
     }


### PR DESCRIPTION
Also increased sample apps api levels as much as possible.
ScenePlayer does not compile with API level 23 because it uses an obsolete FloatMath class in the CircleView class. So it stays behind for now.

closes #15 (at least the pd-for-android part - the btmidi part should be done on the btmidi repository) 
close #13 