### PR TITLE
btmidi on jitpack

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "PdCore/jni/libpd"]
 	path = PdCore/jni/libpd
 	url = git://github.com/libpd/libpd.git
-[submodule "midi"]
-	path = midi
-	url = git://github.com/nettoyeurny/btmidi.git

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile 'com.github.tkirshboim:btmidi:9bc54ccbe1'
+    compile 'com.github.nettoyeurny:btmidi:9bc54ccbe1'
     compile 'com.android.support:support-v4:23.1.0'
 }
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile project(':midi:AndroidMidi')
+    compile 'com.github.tkirshboim:btmidi:9bc54ccbe1'
     compile 'com.android.support:support-v4:23.1.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
The midi submodule repository was updated so that it builds with jitpack.
We can now replace the submodule with the maven artifact from the jitpack repository. This will be one less submodule to worry about and we can still keep track of changes in the midi module by updating the referenced commit.

CircleCI build of the branch: https://circleci.com/gh/tkirshboim/pd-for-android/9