### PR TITLE
Gradle modifications for releasing 'pd-core-1.0.0-rc2' on jcenter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "PdCore/jni/libpd"]
 	path = PdCore/jni/libpd
 	url = git://github.com/libpd/libpd.git
+[submodule "midi"]
+	path = midi
+	url = git@github.com:nettoyeurny/btmidi.git

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -8,7 +8,7 @@ group = 'org.puredata.android'
 
 dependencies {
     embedded project(':midi:AndroidMidi')
-    compile 'com.android.support:support-v4:23.1.0'
+    embedded 'com.android.support:support-v4:23.1.0'
 }
 
 android {

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile 'com.github.nettoyeurny:btmidi:9bc54ccbe1'
+    compile project(':midi:AndroidMidi')
     compile 'com.android.support:support-v4:23.1.0'
 }
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,10 +5,11 @@ apply from: 'fat-aar.gradle'
 
 version = '1.0.0-rc2'
 group = 'org.puredata.android'
+archivesBaseName = 'pd-core'
 
 dependencies {
     embedded project(':midi:AndroidMidi')
-    embedded 'com.android.support:support-v4:23.1.0'
+    compile 'com.android.support:support-v4:23.1.0'
 }
 
 android {
@@ -162,6 +163,7 @@ bintray {
     pkg {
         repo = "maven"
         name = "pd-for-android"
+        userOrg = 'pd-for-android'
         websiteUrl = siteUrl
         vcsUrl = gitUrl
         licenses = ["BSD New"]

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,13 +1,15 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
+apply from: 'fat-aar.gradle'
+
+version = '1.0.0-rc2'
+group = 'org.puredata.android'
 
 dependencies {
-    compile project(':midi:AndroidMidi')
+    embedded project(':midi:AndroidMidi')
     compile 'com.android.support:support-v4:23.1.0'
 }
-
-group = 'org.puredata.android.service'
-archivesBaseName="PdCore"
-version = '1.0'
 
 android {
     compileSdkVersion 23
@@ -87,7 +89,7 @@ def getNdkBuildExecutablePath() {
     File ndkDir = android.ndkDirectory
     if (ndkDir == null) {
         throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
-            'local.properties file or with an ANDROID_NDK_HOME environment variable.')
+                'local.properties file or with an ANDROID_NDK_HOME environment variable.')
     }
     def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
     def ndkBuildFile = new File(ndkDir, isWindows ? 'ndk-build.cmd' : 'ndk-build')
@@ -95,4 +97,74 @@ def getNdkBuildExecutablePath() {
         throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
     }
     ndkBuildFile.absolutePath
+}
+
+def siteUrl = 'https://github.com/libpd/pd-for-android'
+def gitUrl = 'https://github.com/libpd/pd-for-android.git'
+
+install {
+    repositories.mavenInstaller {
+
+        pom {
+            project {
+                packaging 'aar'
+
+                name 'Pure Data for Android'
+                url siteUrl
+
+                licenses {
+                    license {
+                        name 'BSD New'
+                        url 'https://raw.githubusercontent.com/libpd/pd-for-android/master/PdCore/LICENSE.txt'
+                    }
+                }
+
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+
+                }
+            }
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+bintray {
+    if(project.hasProperty("bintray.user") && project.hasProperty("bintray.apikey")) {
+        user = project.property("bintray.user")
+        key = project.property("bintray.apikey")
+    } else {
+        logger.info('Bintray user/apikey not found')
+    }
+
+    configurations = ['archives']
+    pkg {
+        repo = "maven"
+        name = "pd-for-android"
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = ["BSD New"]
+        publish = false
+    }
 }

--- a/PdCore/fat-aar.gradle
+++ b/PdCore/fat-aar.gradle
@@ -1,0 +1,370 @@
+/**
+ * This is free and unencumbered software released into the public domain.
+
+ Anyone is free to copy, modify, publish, use, compile, sell, or
+ distribute this software, either in source code form or as a compiled
+ binary, for any purpose, commercial or non-commercial, and by any
+ means.
+
+ In jurisdictions that recognize copyright laws, the author or authors
+ of this software dedicate any and all copyright interest in the
+ software to the public domain. We make this dedication for the benefit
+ of the public at large and to the detriment of our heirs and
+ successors. We intend this dedication to be an overt act of
+ relinquishment in perpetuity of all present and future rights to this
+ software under copyright law.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+ For more information, please refer to <http://unlicense.org/>
+ */
+
+
+import com.android.annotations.NonNull
+import com.android.manifmerger.ManifestMerger2
+import com.android.manifmerger.ManifestMerger2.Invoker
+import com.android.manifmerger.ManifestMerger2.MergeType
+import com.android.manifmerger.MergingReport
+import com.android.manifmerger.PlaceholderEncoder
+import com.android.manifmerger.XmlDocument
+import com.android.utils.ILogger
+import com.google.common.base.Charsets
+import com.google.common.io.Files
+
+/**
+ * Fat AAR Lib generator v 0.1
+ * Latest version available at https://github.com/adwiv/android-fat-aar
+ * Please report issues at https://github.com/adwiv/android-fat-aar/issues
+ *
+ * This code is in public domain.
+ *
+ * Use at your own risk and only if you understand what it does. You have been warned ! :-)
+ */
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:manifest-merger:24.3.0'
+    }
+}
+
+configurations {
+    embedded
+}
+
+dependencies {
+    compile configurations.embedded
+}
+
+ext.embeddedAarDirs = new ArrayList<String>()
+
+afterEvaluate {
+
+    // the list of dependency must be reversed to use the right overlay order.
+    def dependencies = new ArrayList(configurations.embedded.resolvedConfiguration.firstLevelModuleDependencies)
+    dependencies.reverseEach {
+        def aarPath = "build/intermediates/exploded-aar/${it.moduleGroup}/${it.moduleName}/${it.moduleVersion}"
+        if (!embeddedAarDirs.contains(aarPath)) {
+            embeddedAarDirs.add(aarPath)
+        }
+    }
+
+    // Merge Assets
+    generateReleaseAssets.dependsOn embedAssets
+
+    // Embed Resources by overwriting the inputResourceSets
+    packageReleaseResources.dependsOn embedLibraryResources
+
+    // Merge Native libraries
+    embedJniLibs.mustRunAfter packageReleaseJniLibs
+    bundleRelease.dependsOn embedJniLibs
+
+    // Merge Embedded Manifests
+    embedManifests.mustRunAfter processReleaseManifest
+    bundleRelease.dependsOn embedManifests
+
+    // Generate R.java for each embedded package and ensure it is compiled
+    embedRClassFiles.mustRunAfter processReleaseResources
+
+    // Merge proguard files
+    embedLibraryResources.dependsOn embedProguard
+
+    if (tasks.findByPath('compileReleaseJava') != null) {
+        compileReleaseJava.dependsOn embedRClassFiles
+        embedJavaJars.mustRunAfter compileReleaseJava
+    } else if (tasks.findByPath('compileReleaseJavaWithJavac') != null) {
+        compileReleaseJavaWithJavac.dependsOn embedRClassFiles
+        embedJavaJars.mustRunAfter compileReleaseJavaWithJavac
+    } else {
+        NEEDTOFIX
+    }
+
+    if (tasks.findByPath('proguardRelease') != null) {
+        proguardRelease.dependsOn embedJavaJars
+    }
+
+    bundleRelease.dependsOn embedJavaJars
+}
+
+task embedLibraryResources << {
+    def oldInputResourceSet = packageReleaseResources.inputResourceSets
+    packageReleaseResources.conventionMapping.map("inputResourceSets") {
+        getMergedInputResourceSets(oldInputResourceSet)
+    }
+}
+
+private List getMergedInputResourceSets(List inputResourceSet) {
+    //We need to do this trickery here since the class declared here and that used by the runtime
+    //are different and results in class cast error
+    def ResourceSetClass = inputResourceSet.get(0).class
+
+    List newInputResourceSet = new ArrayList(inputResourceSet)
+
+    embeddedAarDirs.each { aarPath ->
+        try {
+            def resname = (aarPath.split("build/intermediates/exploded-aar/")[1]).replace('/', ':');
+            def rs = ResourceSetClass.newInstance([resname] as Object[])
+            rs.addSource(file("$aarPath/res"))
+            // println "ResourceSet is " + rs
+            newInputResourceSet += rs
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    return newInputResourceSet
+}
+
+/**
+ * Assets are simple files, so just adding them to source set seems to work.
+ */
+task embedAssets << {
+    embeddedAarDirs.each { aarPath ->
+        // Merge Assets
+        android.sourceSets.main.assets.srcDirs += file("$aarPath/assets")
+    }
+}
+
+/**
+ * Merge proguard.txt files from all library modules
+ * @author Marian Kl�hspies
+ */
+task embedProguard << {
+    println "====== Embedding proguard.txt files in " + project
+    def proguardRelease = file("build/intermediates/bundles/release/proguard.txt")
+    embeddedAarDirs.each { aarPath ->
+        try {
+            def proguardLibFile = file("$aarPath/proguard.txt")
+            if (proguardLibFile.exists())
+                proguardRelease.append(proguardLibFile.text)
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}
+
+/**
+ * To embed the class files, we simply explode them in the proper place. Android's packager will
+ * then take care of them and merge them into the classes.jar
+ */
+task embedJavaJars << {
+    embeddedAarDirs.each { aarPath ->
+        // Collect list of all jar files
+        FileTree jars = fileTree(dir: "$aarPath/jars", include: ['*.jar'])
+        jars += fileTree(dir: "$aarPath/jars/libs", include: ['*.jar']);
+        jars += fileTree(dir: "$aarPath", include: ['*.jar']);
+        jars += fileTree(dir: "$aarPath/libs", include: ['*.jar']);
+
+        // println "Embedding jars : " + jars
+
+        // Explode all jar files to classes so that they can be proguarded
+        jars.visit {
+            FileVisitDetails element ->
+                copy {
+                    from(zipTree(element.file))
+                    into("build/intermediates/classes/release/")
+                }
+        }
+    }
+}
+
+/**
+ * For some reason, adding to the jniLibs source set does not work. So we simply copy all files.
+ */
+task embedJniLibs << {
+    println "====== Embedding jni libs in " + project
+    embeddedAarDirs.each { aarPath ->
+        println "======= Copying JNI from $aarPath/jni"
+        // Copy JNI Folders
+        copy {
+            from fileTree(dir: "$aarPath/jni")
+            into file("build/intermediates/bundles/release/jni")
+        }
+    }
+}
+
+/**
+ * Embedding R.java from the embedded libraries is problematic since the constant value changes when
+ * included in the final app. For this reason, the app build process generates the R.class for each
+ * included package. We solve this by generating the R.java for the embedded package and mapping each
+ * entry to the fat library's value. This way, when the fat library's R.class is generated by the
+ * app, the embedded R.class automatically gets the correct value.
+ */
+task embedRClassFiles << {
+    def libPackageName = new XmlParser().parse(android.sourceSets.main.manifest.srcFile).@package
+
+    embeddedAarDirs.each { aarPath ->
+
+        def aarManifest = new XmlParser().parse(file("$aarPath/AndroidManifest.xml"));
+        def aarPackageName = aarManifest.@package
+        String packagePath = aarPackageName.replace('.', '/')
+
+        // Generate the R.java file and map to current project's R.java
+        // This will recreate the class file
+        def rTxt = file("$aarPath/R.txt")
+        def rMap = new ConfigObject()
+
+        if (rTxt.exists()) {
+            rTxt.eachLine {
+                line ->
+                    def (type, subclass, name, value) = line.tokenize(' ')
+                    rMap[subclass].putAt(name, type)
+            }
+        }
+
+        def sb = "package $aarPackageName;" << '\n' << '\n'
+        sb << 'public final class R {' << '\n'
+
+        rMap.each {
+            subclass, values ->
+                sb << "    public static final class $subclass {" << '\n'
+                values.each {
+                    name, type ->
+                        sb << "        public static $type $name = ${libPackageName}.R.${subclass}.${name};" << '\n'
+                }
+                sb << "    }" << '\n'
+        }
+
+        sb << '}' << '\n'
+
+        // println sb
+
+        mkdir("build/generated/source/r/release/$packagePath")
+        file("build/generated/source/r/release/$packagePath/R.java").write(sb.toString())
+    }
+}
+
+task embedManifests << {
+    ILogger mLogger = new MiLogger()
+    List<File> libraryManifests = new ArrayList<>()
+
+    embeddedAarDirs.each { aarPath ->
+        if (!libraryManifests.contains(aarPath)) {
+            libraryManifests.add(file("$aarPath/AndroidManifest.xml"))
+            // println "==== Added $aarPath Manifest"
+        }
+    }
+
+    File reportFile = file("build/embedManifestReport.txt")
+
+    File origManifest = file("build/intermediates/bundles/release/AndroidManifest.xml")
+    File copyManifest = file("build/intermediates/bundles/release/AndroidManifest.orig.xml")
+    File aaptManifest = file("build/intermediates/bundles/release/aapt/AndroidManifest.xml")
+
+    copy {
+        from origManifest.parentFile
+        into copyManifest.parentFile
+        include origManifest.name
+        rename(origManifest.name, copyManifest.name)
+    }
+
+    String outManifestLocation = origManifest.absolutePath
+    String outAaptSafeManifestLocation = aaptManifest.absolutePath
+
+    try {
+        Invoker manifestMergerInvoker = ManifestMerger2.newMerger(copyManifest, mLogger, MergeType.APPLICATION)
+
+        manifestMergerInvoker.addLibraryManifests(libraryManifests.toArray(new File[libraryManifests.size()]))
+
+        // manifestMergerInvoker.setPlaceHolderValues(placeHolders)
+        manifestMergerInvoker.setMergeReportFile(reportFile);
+
+        MergingReport mergingReport = manifestMergerInvoker.merge();
+
+        mLogger.info("Merging result:" + mergingReport.getResult());
+        MergingReport.Result result = mergingReport.getResult();
+        switch (result) {
+            case MergingReport.Result.WARNING:
+                mergingReport.log(mLogger);
+        // fall through since these are just warnings.
+            case MergingReport.Result.SUCCESS:
+                XmlDocument xmlDocument = mergingReport.getMergedDocument().get();
+                try {
+                    String annotatedDocument = mergingReport.getActions().blame(xmlDocument);
+                    mLogger.verbose(annotatedDocument);
+                } catch (Exception e) {
+                    mLogger.error(e, "cannot print resulting xml");
+                }
+                save(xmlDocument, new File(outManifestLocation));
+                if (outAaptSafeManifestLocation != null) {
+                    new PlaceholderEncoder().visit(xmlDocument);
+                    save(xmlDocument, new File(outAaptSafeManifestLocation));
+                }
+                mLogger.info("Merged manifest saved to " + outManifestLocation);
+                break;
+            case MergingReport.Result.ERROR:
+                mergingReport.log(mLogger);
+                throw new RuntimeException(mergingReport.getReportString());
+            default:
+                throw new RuntimeException("Unhandled result type : " + mergingReport.getResult());
+        }
+    } catch (RuntimeException e) {
+        // TODO: unacceptable.
+        e.printStackTrace()
+        throw new RuntimeException(e);
+    }
+}
+
+private void save(XmlDocument xmlDocument, File out) {
+    try {
+        Files.write(xmlDocument.prettyPrint(), out, Charsets.UTF_8);
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+}
+
+class MiLogger implements ILogger {
+
+    @Override
+    void error(
+            @com.android.annotations.Nullable Throwable t,
+            @com.android.annotations.Nullable String msgFormat, Object... args) {
+        System.err.println(String.format("========== ERROR : " + msgFormat, args))
+        if (t) t.printStackTrace(System.err)
+    }
+
+    @Override
+    void warning(@NonNull String msgFormat, Object... args) {
+        System.err.println(String.format("========== WARNING : " + msgFormat, args))
+    }
+
+    @Override
+    void info(@NonNull String msgFormat, Object... args) {
+        System.out.println(String.format("========== INFO : " + msgFormat, args))
+    }
+
+    @Override
+    void verbose(@NonNull String msgFormat, Object... args) {
+        // System.out.println(String.format("========== DEBUG : " + msgFormat, args))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ allprojects {
 }
 ```
 
-Add 'pd-core' as a compile dependency to your app:
+Add the dependency to your app:
 
 ```gradle
 dependencies {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
-
+[ ![Download](https://api.bintray.com/packages/pd-for-android/maven/pd-for-android/images/download.svg) ](https://bintray.com/pd-for-android/maven/pd-for-android/_latestVersion)
 [![Circle CI](https://circleci.com/gh/libpd/pd-for-android/tree/master.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/libpd/pd-for-android/tree/master)
 [![Join the chat at https://gitter.im/libpd/pd-for-android](http://img.shields.io/badge/chat-online-brightgreen.svg)](https://gitter.im/libpd/pd-for-android)
+
+## How to use the library
+
+Make sure you have JCenter in your repositories:
+
+```gradle
+allprojects {
+    repositories {
+        jcenter()
+        // ... other repositories
+    }
+}
+```
+
+Add 'pd-core' as a compile dependency to your app:
+
+```gradle
+dependencies {
+    compile 'org.puredata.android:pd-core:1.0.0-rc2'
+    
+    // ... other dependencies
+}
+```
+
 
 ## How to create an .aar file of pd-for-android
 
@@ -18,5 +42,3 @@ ndk.dir property to the local.properties file or with the ANDROID_NDK_HOME envir
 If you have trouble with your gradle setup or setting your ANDROID_HOME and ANDROID_NDK_HOME
 environment variables (step 4), you can alternatively open Android Studio, import as a Gradle
 Project, open the Gradle Toolbar and run the task assembleRelease in the project :PdCore.
-
-[TBD: Provide hints regarding quirks of the Android SDK, NDK, and Android Studio here.]

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Changes are:
- AndroidMidi rolled back to being a submodule (jcenter doesn't know of jitpack)
- AndroidMidi is now embedded in the pd-core .aar .
We would like to have AndroidMidi also published on JCenter so that the 'fat-aar' gradle code here could be removed. Until happens this is an intermediate solution.

I've tested this using this a copy of the PdTest app that I made that depends on the [RC2](https://bintray.com/pd-for-android/maven/pd-for-android/1.0.0-rc2/view) artifact on JCenter and it works:
https://github.com/tkirshboim/pd-for-android-test 

fixes the issue discussed on #20 