### PR TITLE
Added gradle changes to create maven artefacts for RC3 on JCenter

### DIFF
--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -11,10 +11,6 @@ dependencies {
     compile 'com.android.support:support-v4:23.1.0'
 }
 
-group = 'org.puredata.android.service'
-archivesBaseName="PdCore"
-version = '1.0'
-
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.1'
@@ -93,7 +89,7 @@ def getNdkBuildExecutablePath() {
     File ndkDir = android.ndkDirectory
     if (ndkDir == null) {
         throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
-            'local.properties file or with an ANDROID_NDK_HOME environment variable.')
+                'local.properties file or with an ANDROID_NDK_HOME environment variable.')
     }
     def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
     def ndkBuildFile = new File(ndkDir, isWindows ? 'ndk-build.cmd' : 'ndk-build')
@@ -102,7 +98,6 @@ def getNdkBuildExecutablePath() {
     }
     ndkBuildFile.absolutePath
 }
-
 
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,7 +1,13 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'com.jfrog.bintray'
+
+version = '1.0.0-rc3'
+group = 'org.puredata.android'
+archivesBaseName = 'pd-core'
 
 dependencies {
-    compile 'com.github.nettoyeurny:btmidi:9bc54ccbe1'
+    compile 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
     compile 'com.android.support:support-v4:23.1.0'
 }
 
@@ -95,4 +101,76 @@ def getNdkBuildExecutablePath() {
         throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
     }
     ndkBuildFile.absolutePath
+}
+
+
+def siteUrl = 'https://github.com/libpd/pd-for-android'
+def gitUrl = 'https://github.com/libpd/pd-for-android.git'
+
+install {
+    repositories.mavenInstaller {
+
+        pom {
+            project {
+                packaging 'aar'
+
+                name 'Pure Data for Android'
+                url siteUrl
+
+                licenses {
+                    license {
+                        name 'BSD New'
+                        url 'https://raw.githubusercontent.com/libpd/pd-for-android/master/PdCore/LICENSE.txt'
+                    }
+                }
+
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+
+                }
+            }
+        }
+    }
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+bintray {
+    if(project.hasProperty("bintray.user") && project.hasProperty("bintray.apikey")) {
+        user = project.property("bintray.user")
+        key = project.property("bintray.apikey")
+    } else {
+        logger.info('Bintray user/apikey not found')
+    }
+
+    configurations = ['archives']
+    pkg {
+        repo = "maven"
+        name = "pd-for-android"
+        userOrg = 'pd-for-android'
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = ["BSD New"]
+        publish = false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,15 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven { url "http://dl.bintray.com/pd-for-android/maven" } // remove once AndroidMidi is published on JCenter
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "http://dl.bintray.com/pd-for-android/maven" } // remove once AndroidMidi is published on JCenter
     }
 }
 


### PR DESCRIPTION
RC3 is released on JCenter.
I tested it with a version of the PdTest and it worked:
https://github.com/tkirshboim/pd-for-android-test
I updated the Readme and added a badge that points to the latest release on JCenter.

I also created a wiki page that explains how [How to release on JCenter](https://github.com/libpd/pd-for-android/wiki/How-to-release-on-JCenter)

closes #20 