### PR TITLE
Removed arm64 from NDK build files

### DIFF
--- a/PdCore/jni/Application.mk
+++ b/PdCore/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM := android-9
 APP_OPTIM := release
-APP_ABI := armeabi armeabi-v7a x86 arm64-v8a
+APP_ABI := armeabi armeabi-v7a x86

--- a/PdTest/jni/Application.mk
+++ b/PdTest/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM := android-9
 APP_OPTIM := release
-APP_ABI := armeabi armeabi-v7a x86 arm64-v8a
+APP_ABI := armeabi armeabi-v7a x86

--- a/ScenePlayer/jni/Application.mk
+++ b/ScenePlayer/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM := android-9
 APP_OPTIM := release
-APP_ABI := armeabi armeabi-v7a x86 arm64-v8a
+APP_ABI := armeabi armeabi-v7a x86


### PR DESCRIPTION
This fixes #32 
PdTest from this branch was tested on an ARM 64 bit device and it worked fine - the `helloworld` external as well as fiddle could be created.