### PR TITLE
Add proguard obfuscation and shrinking to PdTest release build.

### DIFF
--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -15,6 +15,13 @@ android {
         versionName "1.0"
     }
 
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -33,7 +40,7 @@ android {
 
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
-        // This moves them out of them default location under src/<type>/... which would
+        // This moves them out of the default location under src/<type>/... which would
         // conflict with src/ being used by the main source set.
         // Adding new build types or product flavors should be accompanied
         // by a similar customization.

--- a/PdTest/proguard-rules.pro
+++ b/PdTest/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Keep PdCore and AndroidMidi classes unchanged.
+-keep class org.puredata.** { *; }
+-keep class com.noisepages.nettoyeur.** { *; }


### PR DESCRIPTION
Enables minify in PdTest release builds, and adds proguard rules to retain PdCore and AndroidMidi components.

TODO: There are some warnings from proguard in the console that should eventually be fixed or silenced, but these rules seem to work for now. Also, we should consider defining some of the common scripts and pieces at a higher level, and then injecting them into the projects where they are needed. This applies to proguard rules as well as ndk-build tasks and methods.