### PR TITLE
Renamed gradle project from PdCore to pd-core

### DIFF
--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':PdCore')
+    compile project(':pd-core')
 }
 
 android {

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.0-rc4'
+version = '1.0.0'
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':PdCore')
+    compile project(':pd-core')
 }
 
 android {

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ dependencies {
 }
 ```
 
-Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.46-7. You can get desktop ditributions of it here:
+Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.46-7. You can get desktop distributions of it here:
 http://msp.ucsd.edu/software.html
 
-If you're building the patch for your app using the extended distribution of Pure Data, or any other distribution that is not vanilla, you should be careful not to use PD objects that are not part of the vanilla distribution, because these will not work with libpd out of the box. It is however possible to add PD externals to your pd-for-android app. For a simple example as to how this could be done see the PdTest app in this repository, specifically [the jni folder](https://github.com/libpd/pd-for-android/tree/master/PdTest/jni) and the [build.gradle](https://github.com/libpd/pd-for-android/tree/master/PdTest/build.gradle) file. If you take this path, you'll need to clone this repository and use it as the base folder for your app, similarly to the way described in the following section on creating an .aar file.
+If you're building the patch for your app using the extended distribution of Pure Data, or any other distribution that is not vanilla, you should be careful not to use PD objects that are not part of the vanilla distribution, because these will not work with libpd out of the box. It is however possible to add PD externals to your pd-for-android app. For a simple example as to how this could be done see the PdTest app in this repository, specifically [the jni folder](https://github.com/libpd/pd-for-android/tree/master/PdTest/jni) and the [build.gradle](https://github.com/libpd/pd-for-android/tree/master/PdTest/build.gradle) file. If you take this path, you'll need to clone this repository and use it as the base folder for your app, similar to the way described in the following section on creating an .aar file.
 
 ## How to create an .aar file of pd-for-android
 

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':PdCore')
+    compile project(':pd-core')
 }
 
 android {

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile project(':PdCore')
+    compile project(':pd-core')
 }
 
 android {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':CircleOfFifths'
-include ':PdCore'
+include ':pd-core'
 include ':Voice-O-Rama'
 include ':PdTest'
 include ':ScenePlayer'
+project(':pd-core').projectDir = new File(rootDir, 'PdCore')


### PR DESCRIPTION
workaround for the [gradle-bintray-plugin issue](https://github.com/bintray/gradle-bintray-plugin/issues/81) that caused the partial failure of the `bintrayUpload` task (see [this](https://github.com/libpd/pd-for-android/wiki/How-to-release-on-JCenter))