### PR TITLE
Updated bintray plugin to 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     }
 }
 


### PR DESCRIPTION
This makes the changes from https://github.com/libpd/pd-for-android/pull/37 obsolete. Version 1.6 of the plugin fixed an issue which now makes the release process simpler. This is reflected in the Wiki: https://github.com/libpd/pd-for-android/wiki/How-to-release-on-JCenter
I've tested it by creating an unpublished release on bintray.