### PR TITLE
Changed version to 1.0.2 and update README

### DIFF
--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.0.2-rc1'
+version = '1.0.2'
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Add the dependency to your app:
 
 ```gradle
 dependencies {
-    compile 'org.puredata.android:pd-core:1.0.1'
+    compile 'org.puredata.android:pd-core:1.0.2-rc1'
     
     // ... other dependencies
 }
 ```
 
-Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.46-7. You can get desktop distributions of it here:
+Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.47-1. You can get desktop distributions of it here:
 http://msp.ucsd.edu/software.html
 
 If you're building the patch for your app using the extended distribution of Pure Data, or any other distribution that is not vanilla, you should be careful not to use PD objects that are not part of the vanilla distribution, because these will not work with libpd out of the box. It is however possible to add PD externals to your pd-for-android app. For a simple example as to how this could be done see the PdTest app in this repository, specifically [the jni folder](https://github.com/libpd/pd-for-android/tree/master/PdTest/jni) and the [build.gradle](https://github.com/libpd/pd-for-android/tree/master/PdTest/build.gradle) file. If you take this path, you'll need to clone this repository and use it as the base folder for your app, similar to the way described in the following section on creating an .aar file.


### PR DESCRIPTION
I've left the instructions in the README file to point to 1.0.2-rc1 to avoid confusion - this should be changed as soon as 1.0.2 is on JCenter.