### PR TITLE
Update android gradle plugin v2.2.1 and other build file changes

### DIFF
--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -27,9 +27,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of them default location under src/<type>/... which would

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -32,9 +32,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of them default location under src/<type>/... which would
@@ -82,7 +79,6 @@ android {
             }
         }
     }
-
 }
 
 def getNdkBuildExecutablePath() {

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -35,9 +35,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of the default location under src/<type>/... which would

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -28,9 +28,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of them default location under src/<type>/... which would

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -26,9 +26,6 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        // Move the tests to tests/java, tests/res, etc...
-        instrumentTest.setRoot('tests')
-
         // Move the build types to build-types/<type>
         // For instance, build-types/debug/java, build-types/debug/AndroidManifest.xml, ...
         // This moves them out of them default location under src/<type>/... which would

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.1'
     }
@@ -17,5 +17,5 @@ allprojects {
 
 ext {
     compileSdkVersion = 24
-    buildToolsVersion = "24.0.0"
+    buildToolsVersion = '24.0.3'
 }

--- a/circle.yml
+++ b/circle.yml
@@ -14,12 +14,16 @@ checkout:
 
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --all --filter "tools"
-    - echo y | android update sdk --no-ui --all --filter "build-tools-24.0.0"
-    - echo y | android update sdk --no-ui --all --filter "android-24"
-    - echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"
+    # Install license hashes to enable auto-update feature in android plugin v2.2.x
+    - mkdir "$ANDROID_HOME/licenses" || true
+    - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+    - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+  override:
+    # Workaround https://code.google.com/p/android/issues/detail?id=212309
+    - ./gradlew dependencies || true
+  post:
+    - ./gradlew clean assembleRelease
 
 test:
   override:
-    - ./gradlew assembleRelease
     - cp -r PdCore/build/outputs/aar $CIRCLE_ARTIFACTS


### PR DESCRIPTION
Details:
* Update android gradle plugin v2.2.1
* Update buildToolsVersion 24.0.3
* Remove instrumentTest configs. Source set name *should* be `androidTest`, but there are none
* CI: Copy licenses to CI machines to enable sdkDownload feature
* CI: Move assembleDebug to dependencies section to leverage gradle cache
