### PR TITLE
Adds 64-bit binaries

### DIFF
--- a/PdCore/jni/Application.mk
+++ b/PdCore/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_PLATFORM := android-17
 APP_OPTIM := release
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -14,6 +14,11 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
+
+        // Uncomment the following 'ndk' section to include only 32-bit CPU architectures in the APK
+        // ndk {
+        //    abiFilters "x86", "armeabi-v7a"
+        // }
     }
 
     buildTypes {

--- a/PdTest/jni/Application.mk
+++ b/PdTest/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_PLATFORM := android-17
 APP_OPTIM := release
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_ALLOW_MISSING_DEPS=true

--- a/ScenePlayer/jni/Application.mk
+++ b/ScenePlayer/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_PLATFORM := android-17
 APP_OPTIM := release
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_ALLOW_MISSING_DEPS=true


### PR DESCRIPTION
Adds 'arm64-v8a' 'x86_64' ABI to PdCore `Application.mk`.

I tested PdTest and ScenePlayer apps with the 64-bit binaries on 64- and 32-bit ARM devices and on a 64-bit Intel based emulator.

closes #60 (see the issue for details)