### PR TITLE
Fix Jcenter publishing

### DIFF
--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
-version = '1.2.0'
+version = '1.2.1-rc1'
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
 
@@ -145,9 +145,16 @@ artifacts {
 }
 
 bintray {
-    if (project.hasProperty("bintray.user") && project.hasProperty("bintray.apikey")) {
-        user = project.property("bintray.user")
-        key = project.property("bintray.apikey")
+    def localProperties = new Properties()
+    def localPropertiesFile = rootProject.file('local.properties')
+    if (localPropertiesFile.exists()) {
+        localProperties.load(localPropertiesFile.newDataInputStream())
+        user = localProperties.getProperty("bintray.user")
+        key = localProperties.getProperty("bintray.apikey")
+    }
+
+    if (user != null &&  key != null) {
+        logger.info('Bintray user/apikey found')
     } else {
         logger.info('Bintray user/apikey not found')
     }

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Add the dependency to your app:
 
 ```gradle
 dependencies {
-    implementation 'org.puredata.android:pd-core:1.1.0'
+    implementation 'org.puredata.android:pd-core:1.2.1-rc1'
     
     // ... other dependencies
 }
 ```
 
-Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.48-0. You can get desktop distributions of it here:
+Please note that pd-for-android depends on the vanilla version of Pure Data. Currently this is Pure Data vanilla version 0.51-3. You can get desktop distributions of it here:
 http://msp.ucsd.edu/software.html
 
 If you're building the patch for your app using the extended distribution of Pure Data, or any other distribution that is not vanilla, you should be careful not to use PD objects that are not part of the vanilla distribution, because these will not work with libpd out of the box. It is however possible to add PD externals to your pd-for-android app. For a simple example as to how this could be done see the PdTest app in this repository, specifically [the jni folder](https://github.com/libpd/pd-for-android/tree/master/PdTest/jni) and the [build.gradle](https://github.com/libpd/pd-for-android/tree/master/PdTest/build.gradle) file. If you take this path, you'll need to clone this repository and use it as the base folder for your app, similar to the way described in the following section on creating an .aar file.


### PR DESCRIPTION
- Remove usage of obsolete 'android-maven-gradle-plugin'.
Maven publishing is supported by the Android plugin.
See https://developer.android.com/studio/build/maven-publish-plugin

- Use git-ignored `local.properties` file for reading Bintray user credentials

- Update documentation to reference latest pd-for-android and PD release versions.