### PR TITLE
fix the build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,8 @@ jobs:
     - run: |
         git submodule sync --recursive
         git submodule update --init --recursive
-    - run: ./gradlew androidDependencies --info
-    - run: ./gradlew clean assembleRelease --info
+    - run: ./gradlew androidDependencies
+    - run: ./gradlew clean assembleRelease
       env:
         JVM_OPTS: -Xmx3200m
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,15 +7,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-      ANDROID_NDK: /usr/local/lib/android/sdk/ndk-bundle
-
     steps:
     - uses: actions/checkout@v2
     - run: |
         git submodule sync --recursive
         git submodule update --init --recursive
-    - run: ./gradlew androidDependencies
+    - run: ./gradlew androidDependencies --info
     - run: ./gradlew clean assembleRelease
       env:
         JVM_OPTS: -Xmx3200m

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      ANDROID_NDK: /usr/local/lib/android/sdk/ndk-bundle
+
     steps:
     - uses: actions/checkout@v2
     - run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ jobs:
     - run: |
         git submodule sync --recursive
         git submodule update --init --recursive
-    - run: ./gradlew androidDependencies --info
+    - run: ./gradlew androidDependencies
     - run: ./gradlew clean assembleRelease
       env:
         JVM_OPTS: -Xmx3200m

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ jobs:
         git submodule sync --recursive
         git submodule update --init --recursive
     - run: ./gradlew androidDependencies --info
-    - run: ./gradlew clean assembleRelease
+    - run: ./gradlew clean assembleRelease --info
       env:
         JVM_OPTS: -Xmx3200m
     - uses: actions/upload-artifact@v2

--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         applicationId "org.puredata.android.fifths"

--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+    ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         applicationId "org.puredata.android.fifths"

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -101,24 +101,6 @@ def findNdkBuildFullPath() {
     return null
 }
 
-def getNdkBuildFullPath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null) {
-        throw new GradleScriptException(
-                'ndk-build binary cannot be found, check if you've set ' +
-                        '$ANDROID_NDK environment variable correctly or if ndk.dir is ' +
-                        'setup in local.properties',
-                null)
-    }
-    if (!new File(ndkBuildFullPath).canExecute()) {
-        throw new GradleScriptException(
-                "ndk-build binary $ndkBuildFullPath doesn't exist or isn't executable.\n" +
-                        'Check that the $ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.',
-                null)
-    }
-    return ndkBuildFullPath
-}
-
 def getNdkBuildExecutablePath() {
     def ndkBuildFullPath = findNdkBuildFullPath()
     if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -78,21 +78,53 @@ android {
     }
 }
 
+def getNdkBuildName() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return 'ndk-build.cmd'
+    } else {
+        return 'ndk-build'
+    }
+}
+
+def findNdkBuildFullPath() {
+    if (System.getenv('ANDROID_NDK') != null) {
+        def ndkDir = System.getenv('ANDROID_NDK')
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
+            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
+                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
+                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+    if (ndkDir) {
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    return null
+}
+
+def getNdkBuildFullPath() {
+    def ndkBuildFullPath = findNdkBuildFullPath()
+    if (ndkBuildFullPath == null) {
+        throw new GradleScriptException(
+                'ndk-build binary cannot be found, check if you've set ' +
+                        '$ANDROID_NDK environment variable correctly or if ndk.dir is ' +
+                        'setup in local.properties',
+                null)
+    }
+    if (!new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException(
+                "ndk-build binary $ndkBuildFullPath doesn't exist or isn't executable.\n" +
+                        'Check that the $ANDROID_NDK environment variable, or ndk.dir in local.properties, is set correctly.',
+                null)
+    }
+    return ndkBuildFullPath
+}
+
 def getNdkBuildExecutablePath() {
-/*
-    File ndkDir = android.ndkDirectory
-    if (ndkDir == null) {
-        throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
-                'local.properties file or with an ANDROID_NDK_HOME environment variable.')
+    def ndkBuildFullPath = findNdkBuildFullPath()
+    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
-    def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
-    def ndkBuildFile = new File(ndkDir, isWindows ? 'ndk-build.cmd' : 'ndk-build')
-    if (!ndkBuildFile.exists()) {
-        throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
-    }
-*/
-    //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
+    return ndkBuildFullPath
 }
 
 def siteUrl = 'https://github.com/libpd/pd-for-android'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -97,18 +97,18 @@ def findNdkBuildFullPath() {
     }
 
     // we allow to provide full path to ndk-build tool
-    if (hasProperty("ndk.command")) {
-        return property("ndk.command")
+    if (hasProperty('ndk.command')) {
+        return property('ndk.command')
     }
     // or just a path to the containing directory
-    if (hasProperty("ndk.path")) {
-        ndkDir = property("ndk.path")
+    if (hasProperty('ndk.path')) {
+        ndkDir = property('ndk.path')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 
     // @FIXME
-    if (System.getenv("ANDROID_NDK_ROOT") != null) {
-        ndkDir = System.getenv("ANDROID_NDK_ROOT")
+    if (System.getenv('ANDROID_NDK_ROOT') != null) {
+        ndkDir = System.getenv('ANDROID_NDK_ROOT')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 version = '1.2.1-rc1'
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -88,6 +88,7 @@ def getNdkBuildName() {
     }
 }
 
+// Adapted from ReactAndroid
 def findNdkBuildFullPath() {
     if (System.getenv('ANDROID_NDK') != null) {
         def ndkDir = System.getenv('ANDROID_NDK')

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -104,6 +104,7 @@ def findNdkBuildFullPath() {
     return null
 }
 
+// TODO: Move to convention plugin
 def getNdkBuildExecutablePath() {
     def ndkBuildFullPath = findNdkBuildFullPath()
     if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -68,10 +68,12 @@ android {
         commandLine ndkBuildExecutablePath, '-C', file('src/main/jni').absolutePath, 'clean'
     }
 
-    clean.dependsOn 'cleanNative'
+    clean.configure {
+        dependsOn tasks.named('cleanNative')
+    }
 
-    tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn 'buildNative'
+    tasks.withType(JavaCompile).configureEach {
+        dependsOn tasks.named('buildNative')
     }
 
     libraryVariants.all { variant ->
@@ -92,6 +94,7 @@ def getNdkBuildExecutablePath() {
     }
     return ndkBuildFullPath
 }
+
 def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"
 
 def siteUrl = 'https://github.com/libpd/pd-for-android'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -95,8 +95,6 @@ def getNdkBuildExecutablePath() {
     return ndkBuildFullPath
 }
 
-def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"
-
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -47,7 +47,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine getNdkBuildExecutablePath(),
+        commandLine ndkBuildExecutablePath,
                 '-C', file('src/main/jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
                 'all',
@@ -65,7 +65,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine getNdkBuildExecutablePath(), '-C', file('src/main/jni').absolutePath, 'clean'
+        commandLine ndkBuildExecutablePath, '-C', file('src/main/jni').absolutePath, 'clean'
     }
 
     clean.dependsOn 'cleanNative'
@@ -81,33 +81,18 @@ android {
     }
 }
 
-def getNdkBuildName() {
-    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
-}
-
-def findNdkBuildFullPath() {
-    // @FIXME
-    if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
-    }
-
-    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
-    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    return null
-}
-
-// TODO: Move to convention plugin
+// TODO: Move to convention plugin?
 def getNdkBuildExecutablePath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory.absolutePath
+    def ndkBuildName = Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
+    def ndkBuildFullPath = new File(ndkDir, ndkBuildName).getAbsolutePath()
+    if (!new File(ndkBuildFullPath).canExecute()) {
         throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
     return ndkBuildFullPath
 }
+def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"
 
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+    ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -81,35 +81,18 @@ android {
 }
 
 def getNdkBuildName() {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        return 'ndk-build.cmd'
-    } else {
-        return 'ndk-build'
-    }
+    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
 }
 
-// Adapted from ReactAndroid
 def findNdkBuildFullPath() {
-
     // @FIXME
     if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        ndkDir = System.getenv('ANDROID_NDK_ROOT')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
     }
 
     // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
     def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    // we allow to provide full path to ndk-build tool
-    if (hasProperty('ndk.command')) {
-        return property('ndk.command')
-    }
-    // or just a path to the containing directory
-    if (hasProperty('ndk.path')) {
-        ndkDir = property('ndk.path')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -15,7 +15,6 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -93,7 +92,7 @@ def getNdkBuildExecutablePath() {
     }
 */
     //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build'
+    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
 }
 
 def siteUrl = 'https://github.com/libpd/pd-for-android'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-version = '1.2.1-rc1'
+version = '1.2.1-rc2'
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -90,17 +90,28 @@ def getNdkBuildName() {
 
 // Adapted from ReactAndroid
 def findNdkBuildFullPath() {
-    if (System.getenv('ANDROID_NDK') != null) {
-        def ndkDir = System.getenv('ANDROID_NDK')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
-                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
-                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
+
+    // we allow to provide full path to ndk-build tool
+    if (hasProperty("ndk.command")) {
+        return property("ndk.command")
+    }
+    // or just a path to the containing directory
+    if (hasProperty("ndk.path")) {
+        ndkDir = property("ndk.path")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
+    // @FIXME
+    if (System.getenv("ANDROID_NDK_ROOT") != null) {
+        ndkDir = System.getenv("ANDROID_NDK_ROOT")
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
     return null
 }
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -90,6 +90,13 @@ def getNdkBuildName() {
 
 // Adapted from ReactAndroid
 def findNdkBuildFullPath() {
+
+    // @FIXME
+    if (System.getenv('ANDROID_NDK_ROOT') != null) {
+        ndkDir = System.getenv('ANDROID_NDK_ROOT')
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+
     // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
     def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
@@ -103,12 +110,6 @@ def findNdkBuildFullPath() {
     // or just a path to the containing directory
     if (hasProperty('ndk.path')) {
         ndkDir = property('ndk.path')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    // @FIXME
-    if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        ndkDir = System.getenv('ANDROID_NDK_ROOT')
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    ndkVersion '21.4.7075529'
+    ndkVersion = '21.4.7075529'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -68,7 +68,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
+        commandLine "${-> getNdkBuildExecutablePath()}"
             'V=1',
             '-C', file('jni').absolutePath,
             'clean'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -67,10 +67,10 @@ android {
         commandLine getNdkBuildExecutablePath(), 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 
-    clean.dependsOn 'cleanNative'
+    clean.dependsOn tasks.named('cleanNative')
 
     tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn 'buildNative'
+        compileTask -> compileTask.dependsOn tasks.named('buildNative')
     }
 }
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -70,7 +70,10 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine getNdkBuildExecutablePath(), 'V=1', '-C', file('jni').absolutePath, 'clean'
+        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
+            'V=1',
+            '-C', file('jni').absolutePath,
+            'clean'
     }
 
     clean.configure {

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    ndkVersion rootProject.ndkVersion
+    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -74,6 +74,7 @@ android {
 
 
 def getNdkBuildExecutablePath() {
+/*
     File ndkDir = android.ndkDirectory
     if (ndkDir == null) {
         throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
@@ -84,5 +85,7 @@ def getNdkBuildExecutablePath() {
     if (!ndkBuildFile.exists()) {
         throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
     }
-    ndkBuildFile.absolutePath
+*/
+    //ndkBuildFile.absolutePath
+    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build'
 }

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
+        commandLine new File('/usr/local/lib/android/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -68,7 +68,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
+        commandLine new File('/usr/local/lib/android/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
             'V=1',
             '-C', file('jni').absolutePath,
             'clean'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -4,7 +4,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 dependencies {
     implementation project(':PdCore')
-    implementation "androidx.legacy:legacy-support-v4:" + rootProject.androidxLegacySupportVersion
+    implementation 'androidx.legacy:legacy-support-v4:' + rootProject.androidxLegacySupportVersion
 }
 
 android {
@@ -16,11 +16,11 @@ android {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
 
         // Uncomment the following 'ndk' section to include only 32-bit CPU architectures in the APK
         // ndk {
-        //    abiFilters "x86", "armeabi-v7a"
+        //    abiFilters 'x86', 'armeabi-v7a'
         // }
     }
 
@@ -76,29 +76,13 @@ android {
     }
 }
 
-def getNdkBuildName() {
-    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
-}
-
-def findNdkBuildFullPath() {
-    // @FIXME
-    if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        //return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
-    }
-
-    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
-    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    return null
-}
-
-// TODO: Move to convention plugin
+// TODO: Move to convention plugin?
 def getNdkBuildExecutablePath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory.absolutePath
+    def ndkBuildName = Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
+    def ndkBuildFullPath = new File(ndkDir, ndkBuildName).getAbsolutePath()
+    if (!new File(ndkBuildFullPath).canExecute()) {
         throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
     return ndkBuildFullPath

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 dependencies {
     implementation project(':PdCore')
     implementation "androidx.legacy:legacy-support-v4:" + rootProject.androidxLegacySupportVersion

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -71,20 +71,35 @@ android {
     }
 }
 
+def getNdkBuildName() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return 'ndk-build.cmd'
+    } else {
+        return 'ndk-build'
+    }
+}
 
+// Adapted from ReactAndroid
+def findNdkBuildFullPath() {
+    if (System.getenv('ANDROID_NDK') != null) {
+        def ndkDir = System.getenv('ANDROID_NDK')
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
+            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
+                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
+                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+    if (ndkDir) {
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    return null
+}
+
+// TODO: Move to convention plugin
 def getNdkBuildExecutablePath() {
-/*
-    File ndkDir = android.ndkDirectory
-    if (ndkDir == null) {
-        throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
-                'local.properties file or with an ANDROID_NDK_HOME environment variable.')
+    def ndkBuildFullPath = findNdkBuildFullPath()
+    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
-    def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
-    def ndkBuildFile = new File(ndkDir, isWindows ? 'ndk-build.cmd' : 'ndk-build')
-    if (!ndkBuildFile.exists()) {
-        throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
-    }
-*/
-    //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
+    return ndkBuildFullPath
 }

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine new File(android.ndkDirectory.absolutePath, 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
+        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -63,10 +63,8 @@ android {
                 'NDK_DEBUG=1'
     }
 
-    tasks.withType(JavaCompile) {
-        compileTask -> compileTask.configure {
-            dependsOn tasks.named('buildNative')
-        }
+    tasks.withType(JavaCompile).configureEach {
+        dependsOn tasks.named('buildNative')
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
@@ -88,7 +86,7 @@ def getNdkBuildName() {
 def findNdkBuildFullPath() {
     // @FIXME
     if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        //return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
+        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
     }
 
     // android.ndkDirectory should return project.android.ndkVersion ndkDirectory

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine new File('/usr/local/lib/android/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
+        commandLine new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -68,7 +68,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine new File('/usr/local/lib/android/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
+        commandLine new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
             'V=1',
             '-C', file('jni').absolutePath,
             'clean'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -87,5 +87,3 @@ def getNdkBuildExecutablePath() {
     }
     return ndkBuildFullPath
 }
-
-def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
+        commandLine "${-> new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath()}", // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -68,7 +68,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine "${-> getNdkBuildExecutablePath()}"
+        commandLine "${-> getNdkBuildExecutablePath()}",
             'V=1',
             '-C', file('jni').absolutePath,
             'clean'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -54,7 +54,7 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
         commandLine getNdkBuildExecutablePath(),
                 'V=1',
                 '-C', file('jni').absolutePath,
@@ -63,7 +63,7 @@ android {
                 'NDK_DEBUG=1'
     }
 
-    tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
+    tasks.register(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
         commandLine getNdkBuildExecutablePath(), 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -54,8 +54,8 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine getNdkBuildExecutablePath(),
+    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+    ndkVersion '21.4.7075529'
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    ndkVersion = '21.4.7075529'
+    ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -54,8 +54,8 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
+    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+        commandLine new File(android.ndkDirectory.absolutePath, 'ndk-build').getAbsolutePath(), // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -69,7 +69,7 @@ android {
         }
     }
 
-    tasks.register(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
+    tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
         commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
             'V=1',
             '-C', file('jni').absolutePath,

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -76,7 +76,7 @@ android {
     clean.configure {
         dependsOn tasks.named('cleanNative')
     }
-]}
+}
 
 def getNdkBuildName() {
     Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -74,26 +74,21 @@ android {
 }
 
 def getNdkBuildName() {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        return 'ndk-build.cmd'
-    } else {
-        return 'ndk-build'
-    }
+    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
 }
 
-// Adapted from ReactAndroid
 def findNdkBuildFullPath() {
-    if (System.getenv('ANDROID_NDK') != null) {
-        def ndkDir = System.getenv('ANDROID_NDK')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    // @FIXME
+    if (System.getenv('ANDROID_NDK_ROOT') != null) {
+        //return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
     }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
-                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
-                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
+
     return null
 }
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -54,7 +54,7 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
         commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
@@ -69,7 +69,7 @@ android {
         }
     }
 
-    tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
+    tasks.register(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
         commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
             'V=1',
             '-C', file('jni').absolutePath,

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine "${-> new File('/usr/local/lib/android/sdk/ndk-bundle', 'ndk-build').getAbsolutePath()}", // getNdkBuildExecutablePath()
+        commandLine "${-> getNdkBuildExecutablePath()}",
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -68,10 +68,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine "${-> getNdkBuildExecutablePath()}",
-            'V=1',
-            '-C', file('jni').absolutePath,
-            'clean'
+        commandLine "${-> getNdkBuildExecutablePath()}", 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 
     clean.configure {
@@ -86,7 +83,7 @@ def getNdkBuildName() {
 def findNdkBuildFullPath() {
     // @FIXME
     if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
+        //return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
     }
 
     // android.ndkDirectory should return project.android.ndkVersion ndkDirectory

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -26,7 +26,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
+            minifyEnabled false // @FIXME
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -26,7 +26,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false // @FIXME
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -54,7 +54,7 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
         commandLine getNdkBuildExecutablePath(),
                 'V=1',
                 '-C', file('jni').absolutePath,
@@ -63,7 +63,7 @@ android {
                 'NDK_DEBUG=1'
     }
 
-    tasks.register(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
+    tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
         commandLine getNdkBuildExecutablePath(), 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -87,5 +86,5 @@ def getNdkBuildExecutablePath() {
     }
 */
     //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build'
+    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
 }

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -54,7 +54,7 @@ android {
         release.setRoot('build-types/release')
     }
 
-    tasks.register(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
+    tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
         commandLine '/usr/local/lib/android/ndk-bundle/ndk-build', // getNdkBuildExecutablePath()
                 'V=1',
                 '-C', file('jni').absolutePath,
@@ -63,16 +63,20 @@ android {
                 'NDK_DEBUG=1'
     }
 
+    tasks.withType(JavaCompile) {
+        compileTask -> compileTask.configure {
+            dependsOn tasks.named('buildNative')
+        }
+    }
+
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
         commandLine getNdkBuildExecutablePath(), 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 
-    clean.dependsOn tasks.named('cleanNative')
-
-    tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn tasks.named('buildNative')
+    clean.configure {
+        dependsOn tasks.named('cleanNative')
     }
-}
+]}
 
 def getNdkBuildName() {
     Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -55,7 +55,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine "${-> getNdkBuildExecutablePath()}",
+        commandLine ndkBuildExecutablePath,
                 'V=1',
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
@@ -63,16 +63,16 @@ android {
                 'NDK_DEBUG=1'
     }
 
-    tasks.withType(JavaCompile).configureEach {
-        dependsOn tasks.named('buildNative')
-    }
-
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine "${-> getNdkBuildExecutablePath()}", 'V=1', '-C', file('jni').absolutePath, 'clean'
+        commandLine ndkBuildExecutablePath, 'V=1', '-C', file('jni').absolutePath, 'clean'
     }
 
     clean.configure {
         dependsOn tasks.named('cleanNative')
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        dependsOn tasks.named('buildNative')
     }
 }
 
@@ -87,3 +87,5 @@ def getNdkBuildExecutablePath() {
     }
     return ndkBuildFullPath
 }
+
+def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    ndkVersion rootProject.ndkVersion
+    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -63,6 +63,7 @@ android {
 }
 
 def getNdkBuildExecutablePath() {
+/*
     File ndkDir = android.ndkDirectory
     if (ndkDir == null) {
         throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
@@ -73,5 +74,7 @@ def getNdkBuildExecutablePath() {
     if (!ndkBuildFile.exists()) {
         throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
     }
-    ndkBuildFile.absolutePath
+*/
+    //ndkBuildFile.absolutePath
+    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build'
 }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -77,5 +77,3 @@ def getNdkBuildExecutablePath() {
     }
     return ndkBuildFullPath
 }
-
-def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
+    ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -41,7 +42,7 @@ android {
     }
 
     tasks.create(name: 'buildNative', type: Exec, description: 'Compile JNI source via NDK') {
-        commandLine getNdkBuildExecutablePath(),
+        commandLine ndkBuildExecutablePath,
                 '-C', file('jni').absolutePath,
                 '-j', Runtime.runtime.availableProcessors(),
                 'all',
@@ -49,7 +50,7 @@ android {
     }
 
     tasks.create(name: 'cleanNative', type: Exec, description: 'Clean JNI object files') {
-        commandLine getNdkBuildExecutablePath(), '-C', file('jni').absolutePath, 'clean'
+        commandLine ndkBuildExecutablePath, '-C', file('jni').absolutePath, 'clean'
     }
 
     clean.dependsOn 'cleanNative'
@@ -63,30 +64,16 @@ android {
     }
 }
 
-def getNdkBuildName() {
-    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
-}
-
-def findNdkBuildFullPath() {
-    // @FIXME
-    if (System.getenv('ANDROID_NDK_ROOT') != null) {
-        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
-    }
-
-    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
-    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
-    if (ndkDir) {
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
-    }
-
-    return null
-}
-
-// TODO: Move to convention plugin
+// TODO: Move to convention plugin?
 def getNdkBuildExecutablePath() {
-    def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory.absolutePath
+    def ndkBuildName = Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
+    def ndkBuildFullPath = new File(ndkDir, ndkBuildName).getAbsolutePath()
+    if (!new File(ndkBuildFullPath).canExecute()) {
         throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
     return ndkBuildFullPath
 }
+
+def ndkNBuildExecutablePath = "${{-> getNdkBuildExecutablePath()}.memoize()}"

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 dependencies {
     implementation project(':PdCore')
 }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -61,19 +61,35 @@ android {
     }
 }
 
+def getNdkBuildName() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return 'ndk-build.cmd'
+    } else {
+        return 'ndk-build'
+    }
+}
+
+// Adapted from ReactAndroid
+def findNdkBuildFullPath() {
+    if (System.getenv('ANDROID_NDK') != null) {
+        def ndkDir = System.getenv('ANDROID_NDK')
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
+            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
+                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
+                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+    if (ndkDir) {
+        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    }
+    return null
+}
+
+// TODO: Move to convention plugin
 def getNdkBuildExecutablePath() {
-/*
-    File ndkDir = android.ndkDirectory
-    if (ndkDir == null) {
-        throw new Exception('NDK location not found. Define location with ndk.dir in the ' +
-                'local.properties file or with an ANDROID_NDK_HOME environment variable.')
+    def ndkBuildFullPath = findNdkBuildFullPath()
+    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException("ndk-build executable not found: $ndkBuildFullPath")
     }
-    def isWindows = System.properties['os.name'].toLowerCase().contains('windows')
-    def ndkBuildFile = new File(ndkDir, isWindows ? 'ndk-build.cmd' : 'ndk-build')
-    if (!ndkBuildFile.exists()) {
-        throw new Exception("ndk-build executable not found: $ndkBuildFile.absolutePath")
-    }
-*/
-    //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
+    return ndkBuildFullPath
 }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
@@ -76,5 +75,5 @@ def getNdkBuildExecutablePath() {
     }
 */
     //ndkBuildFile.absolutePath
-    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build'
+    '/usr/local/lib/android/sdk/ndk-bundle/ndk-build' // FIXME:
 }

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -53,10 +53,12 @@ android {
         commandLine ndkBuildExecutablePath, '-C', file('jni').absolutePath, 'clean'
     }
 
-    clean.dependsOn 'cleanNative'
+    clean.configure {
+        dependsOn tasks.named('cleanNative')
+    }
 
-    tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn 'buildNative'
+    tasks.withType(JavaCompile).configureEach {
+        dependsOn tasks.named('buildNative')
     }
 
     lintOptions {

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -64,26 +64,21 @@ android {
 }
 
 def getNdkBuildName() {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        return 'ndk-build.cmd'
-    } else {
-        return 'ndk-build'
-    }
+    Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
 }
 
-// Adapted from ReactAndroid
 def findNdkBuildFullPath() {
-    if (System.getenv('ANDROID_NDK') != null) {
-        def ndkDir = System.getenv('ANDROID_NDK')
-        return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
+    // @FIXME
+    if (System.getenv('ANDROID_NDK_ROOT') != null) {
+        return new File(System.getenv('ANDROID_NDK_ROOT'), getNdkBuildName()).getAbsolutePath()
     }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
-                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
-                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
+
+    // android.ndkDirectory should return project.android.ndkVersion ndkDirectory
+    def ndkDir = android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
+
     return null
 }
 

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    ndkVersion rootProject.ndkVersion
+    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 android {
     compileSdkVersion rootProject.compileSdkVersion
     buildToolsVersion rootProject.buildToolsVersion
-    //ndkVersion rootProject.ndkVersion
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -24,5 +24,5 @@ ext {
     compileSdkVersion = 30
     buildToolsVersion = '30.0.2'
     androidxLegacySupportVersion = '1.0.0'
-    ndkVersion = '21.4.7075529'
+    ndkVersion = '21.4.7075529' // https://developer.android.com/ndk/downloads#lts-downloads
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter() // FIXME:
+        jcenter() // @FIXME
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -15,7 +15,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() // FIXME:
+        jcenter() // @FIXME
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,5 +24,5 @@ ext {
     compileSdkVersion = 30
     buildToolsVersion = '30.0.2'
     androidxLegacySupportVersion = '1.0.0'
-    // Use AGP's default ndkVersion
+    ndkVersion = '21.4.7075529'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,5 +24,5 @@ ext {
     compileSdkVersion = 30
     buildToolsVersion = '30.0.2'
     androidxLegacySupportVersion = '1.0.0'
-    //ndkVersion = "21.3.6528147"
+    // Use AGP's default ndkVersion
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixing the build before I tackle the publish changes...

The build problem was because gradle could not resolve the `ndk-build` path.

The root cause of failure was that `getNdkBuildExecutionPath` was being evaluated too early. However, the builds still succeeded for a while because `ANDROID_NDK_HOME` was provided by GitHub Action's builder. When AGP stopped reading the env var, our builds failed.

Note that GitHub Action's builder image has the LTS version baked-in:

https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/android.sh

This is the `ndkVersion` we specify, saving us from having to install it ourselves.

NOTE: THESE COMMITS SHOULD BE SQUASHED WHEN MERGING.