### PR TITLE
publish to GitHub Packages

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    - if: github.event_name == 'push'
-      run: ./gradlew publish --info
+    # - if: github.event_name == 'push'
+    - run: ./gradlew publish --info
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,6 +20,6 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    - run: ./gradlew publish
+    - run: ./gradlew publish --info
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - run: echo ${{github.event.inputs.publish-version}}
     - uses: actions/checkout@v2
     - run: |
         git submodule sync --recursive
@@ -32,6 +33,6 @@ jobs:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
     - if: github.event_name == 'workflow_dispatch'
-      run: ./gradlew publish -Pgpr.version={{github.event.inputs.publish-version}} --info
+      run: ./gradlew publish -Pgpr.version=${{github.event.inputs.publish-version}} --info
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,3 +20,4 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
+    - run: ./gradlew publish --dry-run

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    # - if: github.event_name == 'push'
-    - run: ./gradlew publish --info
+    - if: github.event_name == 'push'
+      run: ./gradlew publish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,15 +3,12 @@ name: Android CI
 on:
   push:
     branches:
-      - master
+    - master
+    paths-ignore:
+    - '**/README.md'
   pull_request:
     branches:
-      - master
-  workflow_dispatch:
-    inputs:
-      publish-version:
-        description: 'Enter version to publish'
-        required: true
+    - master
 
 jobs:
   build:
@@ -19,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: echo ${{github.event.inputs.publish-version}}
     - uses: actions/checkout@v2
     - run: |
         git submodule sync --recursive
@@ -32,7 +28,7 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    - if: github.event_name == 'workflow_dispatch'
-      run: ./gradlew publish -Pgpr.version=${{github.event.inputs.publish-version}} --info
+    - if: github.event_name == 'push'
+      run: ./gradlew publish --info
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,17 @@
 name: Android CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      publish-version:
+        description: 'Enter version to publish'
+        required: true
 
 jobs:
   build:
@@ -20,6 +31,7 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    - run: ./gradlew publish --info
+    - if: github.event_name == 'workflow_dispatch'
+      run: ./gradlew publish -Pgpr.version={{github.event.inputs.publish-version}} --info
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,3 +21,5 @@ jobs:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
     - run: ./gradlew publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,4 +20,4 @@ jobs:
       with:
         name: pd-core-aar
         path: PdCore/build/outputs/aar
-    - run: ./gradlew publish --dry-run
+    - run: ./gradlew publish

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = System.getenv('GITHUB_REF') ?: 'SNAPSHOT' // FIXME:
+version = '1.2.1-test1' // System.getenv('GITHUB_REF') ?: 'SNAPSHOT' // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -3,9 +3,9 @@ apply plugin: 'maven-publish'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-version = '1.2.1-rc2'
-group = 'org.puredata.android'
-archivesBaseName = 'pd-core'
+groupId = 'org.puredata.android'
+artifactId = 'pd-core'
+version = ${GITHUB_REF} // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
@@ -77,7 +77,7 @@ android {
 
     libraryVariants.all { variant ->
         variant.outputs.all { output ->
-            outputFileName = "${archivesBaseName}-${version}.aar"
+            outputFileName = "${artifactId}.aar"
         }
     }
 }
@@ -94,56 +94,41 @@ def getNdkBuildExecutablePath() {
     return ndkBuildFullPath
 }
 
-//implementation 'org.puredata.android:pd-core:1.2.1-rc1'
-
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 
 publishing {
     publications {
         myPulication(MavenPublication) {
-            groupId group
-            version version
-            artifactId archivesBaseName
-            artifact("$buildDir/outputs/aar/myProject.aar")
-        }
-    }
-    repositories {
-        maven {
-            url "http://www.myrepository.com"
-        }
-    }
-}
-
-/*
-install {
-    repositories.mavenInstaller {
-
-        pom {
-            project {
-                packaging 'aar'
-
-                name 'Pure Data for Android'
-                url siteUrl
-
+            groupId
+            artifactId
+            version
+            artifact "$buildDir/outputs/aar/${artifactId}.aar"
+            //artifact sourcesJar
+            //artifact javadocJar
+            pom {
+                name ='Pure Data for Android'
+                url = siteUrl
                 licenses {
                     license {
-                        name 'BSD New'
-                        url 'https://raw.githubusercontent.com/libpd/pd-for-android/master/PdCore/LICENSE.txt'
+                        name = 'BSD New'
+                        url = 'https://raw.githubusercontent.com/libpd/pd-for-android/master/PdCore/LICENSE.txt'
                     }
                 }
-
                 scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
-
+                    connection = gitUrl
+                    developerConnection = gitUrl
+                    url = siteUrl
                 }
             }
         }
     }
+    repositories {
+        maven {
+            url "https://maven.pkg.github.com/libpd/pd-for-android"
+        }
+    }
 }
-*/
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -125,7 +125,7 @@ publishing {
             version version
             artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar" // TODO: from components
             artifact sourcesJar
-            artifact javadocJar
+            //artifact javadocJar
             pom {
                 name ='Pure Data for Android'
                 url = siteUrl

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = '1.2.1-test1' // System.getenv('GITHUB_REF') ?: 'SNAPSHOT' // FIXME:
+version = '1.2.1-' + (System.getenv('GITHUB_REF') ?: 'SNAPSHOT') // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -103,7 +103,7 @@ publishing {
             groupId group
             artifactId archivesBaseName
             version version
-            artifact "$buildDir/outputs/aar/$archivesBaseName.aar"
+            artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar"
             //artifact sourcesJar
             //artifact javadocJar
             pom {

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -104,7 +104,7 @@ publishing {
         myPulication(MavenPublication) {
             groupId group
             version version
-            artifactId archiveBaseName
+            artifactId archivesBaseName
             artifact("$buildDir/outputs/aar/myProject.aar")
         }
     }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = '1.2.1-' + (System.getenv('GITHUB_REF') ?: 'SNAPSHOT') // FIXME:
+version = findProperty('gpr.version') ?: '1.2.1-rc3'
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
@@ -124,8 +124,8 @@ publishing {
             artifactId archivesBaseName
             version version
             artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar" // TODO: from components
-            //artifact sourcesJar
-            //artifact javadocJar
+            artifact sourcesJar
+            artifact javadocJar
             pom {
                 name ='Pure Data for Android'
                 url = siteUrl
@@ -148,8 +148,8 @@ publishing {
             name = 'GitHubPackages'
             url = uri('https://maven.pkg.github.com/libpd/pd-for-android')
             credentials {
-                username = project.findProperty('gpr.user') ?: System.getenv('GITHUB_REPOSITORY')
-                password = project.findProperty('gpr.key') ?: System.getenv('GITHUB_TOKEN')
+                username = findProperty('gpr.user') ?: System.getenv('GITHUB_REPOSITORY')
+                password = findProperty('gpr.key') ?: System.getenv('GITHUB_TOKEN')
             }
         }
     }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-//apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -94,9 +94,28 @@ def getNdkBuildExecutablePath() {
     return ndkBuildFullPath
 }
 
+//implementation 'org.puredata.android:pd-core:1.2.1-rc1'
+
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 
+publishing {
+    publications {
+        myPulication(MavenPublication) {
+            groupId group
+            version version
+            artifactId archiveBaseName
+            artifact("$buildDir/outputs/aar/myProject.aar")
+        }
+    }
+    repositories {
+        maven {
+            url "http://www.myrepository.com"
+        }
+    }
+}
+
+/*
 install {
     repositories.mavenInstaller {
 
@@ -124,6 +143,7 @@ install {
         }
     }
 }
+*/
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = 'SNAPSHOT' // ${GITHUB_REF} // FIXME:
+version = System.getenv('GITHUB_REF') ?: 'SNAPSHOT' // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
@@ -94,6 +94,26 @@ def getNdkBuildExecutablePath() {
     return ndkBuildFullPath
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
 def siteUrl = 'https://github.com/libpd/pd-for-android'
 def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 
@@ -103,7 +123,7 @@ publishing {
             groupId group
             artifactId archivesBaseName
             version version
-            artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar"
+            artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar" // TODO: from components
             //artifact sourcesJar
             //artifact javadocJar
             pom {
@@ -128,24 +148,4 @@ publishing {
             url 'https://maven.pkg.github.com/libpd/pd-for-android'
         }
     }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
 }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = findProperty('gpr.version') ?: '1.2.1-rc4'
+version = findProperty('gpr.version') ?: '1.2.1-rc5'
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -119,7 +119,7 @@ def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 
 publishing {
     publications {
-        myPulication(MavenPublication) {
+        gpr(MavenPublication) {
             groupId group
             artifactId archivesBaseName
             version version
@@ -140,6 +140,16 @@ publishing {
                     developerConnection = gitUrl
                     url = siteUrl
                 }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = 'GitHubPackages'
+            url = uri('https://maven.pkg.github.com/libpd/pd-for-android')
+            credentials {
+                username = project.findProperty('gpr.user') ?: System.getenv('GITHUB_REPOSITORY')
+                password = project.findProperty('gpr.key') ?: System.getenv('GITHUB_TOKEN')
             }
         }
     }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'maven-publish'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
-groupId = 'org.puredata.android'
-artifactId = 'pd-core'
+group = 'org.puredata.android'
+archivesBaseName = 'pd-core'
 version = 'SNAPSHOT' // ${GITHUB_REF} // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
     implementation 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
-    implementation "androidx.legacy:legacy-support-v4:" + rootProject.androidxLegacySupportVersion
+    implementation 'androidx.legacy:legacy-support-v4:' + rootProject.androidxLegacySupportVersion
 }
 
 android {
@@ -77,7 +77,7 @@ android {
 
     libraryVariants.all { variant ->
         variant.outputs.all { output ->
-            outputFileName = "${artifactId}.aar"
+            outputFileName = "${archivesBaseName}.aar"
         }
     }
 }
@@ -100,10 +100,10 @@ def gitUrl = 'https://github.com/libpd/pd-for-android.git'
 publishing {
     publications {
         myPulication(MavenPublication) {
-            groupId
-            artifactId
-            version
-            artifact "$buildDir/outputs/aar/${artifactId}.aar"
+            groupId group
+            artifactId archivesBaseName
+            version version
+            artifact "$buildDir/outputs/aar/$archivesBaseName.aar"
             //artifact sourcesJar
             //artifact javadocJar
             pom {
@@ -125,7 +125,7 @@ publishing {
     }
     repositories {
         maven {
-            url "https://maven.pkg.github.com/libpd/pd-for-android"
+            url 'https://maven.pkg.github.com/libpd/pd-for-android'
         }
     }
 }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -144,31 +143,4 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 artifacts {
     archives javadocJar
     archives sourcesJar
-}
-
-bintray {
-    def localProperties = new Properties()
-    def localPropertiesFile = rootProject.file('local.properties')
-    if (localPropertiesFile.exists()) {
-        localProperties.load(localPropertiesFile.newDataInputStream())
-        user = localProperties.getProperty("bintray.user")
-        key = localProperties.getProperty("bintray.apikey")
-    }
-
-    if (user != null &&  key != null) {
-        logger.info('Bintray user/apikey found')
-    } else {
-        logger.info('Bintray user/apikey not found')
-    }
-
-    configurations = ['archives']
-    pkg {
-        repo = "maven"
-        name = "pd-for-android"
-        userOrg = 'pd-for-android'
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = ["BSD New"]
-        publish = false
-    }
 }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 groupId = 'org.puredata.android'
 artifactId = 'pd-core'
-version = ${GITHUB_REF} // FIXME:
+version = 'SNAPSHOT' // ${GITHUB_REF} // FIXME:
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 group = 'org.puredata.android'
 archivesBaseName = 'pd-core'
-version = findProperty('gpr.version') ?: '1.2.1-rc3'
+version = findProperty('gpr.version') ?: '1.2.1-rc4'
 
 dependencies {
     api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
@@ -124,7 +124,7 @@ publishing {
             artifactId archivesBaseName
             version version
             artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar" // TODO: from components
-            //artifact sourcesJar
+            artifact sourcesJar
             //artifact javadocJar
             pom {
                 name ='Pure Data for Android'

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -124,7 +124,7 @@ publishing {
             artifactId archivesBaseName
             version version
             artifact "${buildDir}/outputs/aar/${archivesBaseName}.aar" // TODO: from components
-            artifact sourcesJar
+            //artifact sourcesJar
             //artifact javadocJar
             pom {
                 name ='Pure Data for Android'
@@ -151,11 +151,6 @@ publishing {
                 username = findProperty('gpr.user') ?: System.getenv('GITHUB_REPOSITORY')
                 password = findProperty('gpr.key') ?: System.getenv('GITHUB_TOKEN')
             }
-        }
-    }
-    repositories {
-        maven {
-            url 'https://maven.pkg.github.com/libpd/pd-for-android'
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        //classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter() // @FIXME
+        //jcenter() // @FIXME
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        //classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 
@@ -15,7 +15,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() // @FIXME
+        //jcenter() // @FIXME
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        //jcenter() // @FIXME
+        jcenter() // FIXME: com.noisepages.nettoyeur:midi
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,10 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        //jcenter() // @FIXME
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        //classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        //classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 


### PR DESCRIPTION
Changes:
* Remove bintray - EXCEPT for `com.noisepages.nettoyeur:midi` which is not found elsewhere: https://github.com/nettoyeurny/btmidi/issues/10
* Add maven publish task which runs on every push to master
* Add properties `gpr.version`, ` gpr.user`, and `gpr.key` to support manual overrides

When this is merged, version 1.2.1-rc5 will be published to [GitHub Packages](https://github.com/orgs/libpd/packages?repo_name=pd-for-android)

The _push-to-master_ publication trigger requires that we update the version in PdCore for every PR (ignoring README changes). I've found that this works OK, but if it doesn't we can explore other triggers such as publishing when releases are created, publishing when release tags are pushed, or publishing when dispatched manually (`workflow_dispatch` event).

To install this library from GitHub Packages: 

https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages#installing-a-package

Installation currently requires a token, but GitHub staff say they are planning to allow anonymous access to public package registries, as they have already done for their container registry.

NOTE: SQUASH COMMITS BEFORE MERGING