### PR TITLE
Raise target SDK to 33 for PdCore and PdTest

### DIFF
--- a/CircleOfFifths/AndroidManifest.xml
+++ b/CircleOfFifths/AndroidManifest.xml
@@ -3,7 +3,8 @@
 	package="org.puredata.android.fifths" >
 	<application android:icon="@drawable/icon" android:label="@string/app_name">
 		<activity android:name=".CircleOfFifths" android:label="@string/app_name"
-			android:screenOrientation="portrait" android:theme="@style/DisableSoundEffects">
+			android:screenOrientation="portrait" android:theme="@style/DisableSoundEffects"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/CircleOfFifths/build.gradle
+++ b/CircleOfFifths/build.gradle
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId "org.puredata.android.fifths"
         minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 3
         versionName "0.3"
     }

--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName version
     }

--- a/PdTest/AndroidManifest.xml
+++ b/PdTest/AndroidManifest.xml
@@ -3,18 +3,23 @@
 	package="org.puredata.android.test">
 	<application android:icon="@drawable/icon" android:label="@string/app_name" android:theme="@style/DisableSoundEffects">
 		<activity android:label="@string/app_name" android:name=".PdTest"
-			android:screenOrientation="portrait" android:launchMode="singleTask">
+			android:screenOrientation="portrait" android:launchMode="singleTask"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-		<service android:name="org.puredata.android.service.PdService" />
+		<service android:name="org.puredata.android.service.PdService"
+			android:foregroundServiceType="mediaPlayback|microphone"/>
 		<activity android:label="Pure Data Preferences"
 			android:name="org.puredata.android.service.PdPreferences"
 			android:screenOrientation="portrait" />
 	</application>
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
     	<uses-permission android:name="android.permission.BLUETOOTH" />
-</manifest> 
+</manifest>

--- a/PdTest/build.gradle
+++ b/PdTest/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName '1.0'
 

--- a/PdTest/src/org/puredata/android/test/PdTest.java
+++ b/PdTest/src/org/puredata/android/test/PdTest.java
@@ -27,6 +27,7 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
@@ -245,7 +246,7 @@ public class PdTest extends Activity implements OnClickListener, OnEditorActionL
 	@Override
 	public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
 										   @NonNull int[] grantResults) {
-		if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+		if (recordAudioPermissionGranted()) {
 			startAudio();
 		} else {
 			toast("Can't start audio - microphone permission required!");
@@ -261,7 +262,7 @@ public class PdTest extends Activity implements OnClickListener, OnEditorActionL
 			} else if (recordAudioPermissionGranted()) {
 				startAudio();
 			} else {
-				requestAudioPermission();
+				requestPermissions();
 			}
 
 			PdBase.sendFloat("left", left.isChecked() ? 1 : 0);
@@ -335,7 +336,13 @@ public class PdTest extends Activity implements OnClickListener, OnEditorActionL
 		return permissionResult == PackageManager.PERMISSION_GRANTED;
 	}
 
-	private void requestAudioPermission() {
-		ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, 0);
+	private void requestPermissions() {
+		String[] permissions;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+			permissions = new String[]{Manifest.permission.RECORD_AUDIO, Manifest.permission.POST_NOTIFICATIONS};
+		} else {
+			permissions = new String[]{Manifest.permission.RECORD_AUDIO};
+		}
+		ActivityCompat.requestPermissions(this, permissions, 0);
 	}
 }

--- a/ScenePlayer/AndroidManifest.xml
+++ b/ScenePlayer/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
     <supports-screens android:smallScreens="false" />
 
@@ -18,7 +22,8 @@
         <activity
             android:label="@string/app_name"
             android:name=".SceneTabs"
-            android:screenOrientation="portrait" >
+            android:screenOrientation="portrait"
+            android:exported="true">
             <intent-filter >
                 <action android:name="android.intent.action.MAIN" />
 
@@ -57,6 +62,7 @@
             android:screenOrientation="portrait"
             android:theme="@style/FullScreen.DisableSoundEffects" />
 
-        <service android:name="org.puredata.android.service.PdService" />
+        <service android:name="org.puredata.android.service.PdService"
+            android:foregroundServiceType="mediaPlayback|microphone"/>
     </application>
 </manifest>

--- a/ScenePlayer/build.gradle
+++ b/ScenePlayer/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 11
         versionName "0.9.2"
     }

--- a/Voice-O-Rama/AndroidManifest.xml
+++ b/Voice-O-Rama/AndroidManifest.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="at.or.at.voiceorama">
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 	<application android:icon="@drawable/icon" android:label="@string/app_name" android:allowBackup="true">
 		<activity android:label="@string/app_name" android:name=".VoiceORama"
-			android:configChanges="orientation" android:launchMode="singleTask">
+			android:configChanges="orientation" android:launchMode="singleTask"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-		<service android:name="org.puredata.android.service.PdService" />
+		<service android:name="org.puredata.android.service.PdService"
+			android:foregroundServiceType="mediaPlayback|microphone"/>
 		<activity android:label="Pure Data Preferences"
 			android:name="org.puredata.android.service.PdPreferences"
 			android:configChanges="orientation">

--- a/Voice-O-Rama/build.gradle
+++ b/Voice-O-Rama/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 11
         versionName "1.0"
     }


### PR DESCRIPTION
- Target SDK for other apps was raised to the minimum SDK which is 28.
- Also fixes #121 and therefore also closes #120 .

I tested PdTest on Android 28 and 33 emulators and was able to get audio input and output.

The other apps seem to no longer work as expected, probably because they are not requesting runtime permissions.