### PR TITLE
Give up com.noisepages.nettoyeur:midi and reimplement Midi

### DIFF
--- a/PdCore/build.gradle
+++ b/PdCore/build.gradle
@@ -9,8 +9,6 @@ archivesBaseName = 'pd-core'
 version = rootProject.version
 
 dependencies {
-    api 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
-    implementation 'com.noisepages.nettoyeur:midi:1.0.0-rc1'
     implementation 'androidx.legacy:legacy-support-v4:' + rootProject.androidxLegacySupportVersion
 }
 

--- a/PdCore/src/main/java/org/puredata/android/midi/MidiToPdAdapter.java
+++ b/PdCore/src/main/java/org/puredata/android/midi/MidiToPdAdapter.java
@@ -8,61 +8,88 @@
 package org.puredata.android.midi;
 
 import org.puredata.core.PdBase;
-
-import com.noisepages.nettoyeur.midi.MidiReceiver;
+import android.media.midi.MidiReceiver;
 
 /**
  * Adapter class for connecting output from AndroidMidi to MIDI input for Pd.
  * 
  * @author Peter Brinkmann (peter.brinkmann@gmail.com)
+ * @author Antoine Rousseau (antoine@metalu.net)
  */
-public class MidiToPdAdapter implements MidiReceiver {
+public class MidiToPdAdapter extends MidiReceiver {
+	private static enum State {
+		NOTE_OFF, NOTE_ON, POLY_TOUCH, CONTROL_CHANGE, PROGRAM_CHANGE, AFTERTOUCH, PITCH_BEND, NONE
+	}
+	private State midiState = State.NONE;
+	private int channel;
+	private int firstByte;
 
 	@Override
-	public void onRawByte(byte value) {
-		PdBase.sendMidiByte(0, value);
+	public void onSend(byte[] msg, int offset, int count, long timestamp) {
+		while(count-- != 0) processByte(msg[offset++]);
 	}
 
-	@Override
-	public void onProgramChange(int channel, int program) {
-		PdBase.sendProgramChange(channel, program);
+	private void processByte(int b) {
+		if (b < 0) {
+			midiState = State.values()[(b >> 4) & 0x07];
+			if (midiState != State.NONE) {
+				channel = b & 0x0f;
+				firstByte = -1;
+			} else {
+				PdBase.sendMidiByte(0, b);
+			}
+		} else {
+			switch (midiState) {
+			case NOTE_OFF:
+				if (firstByte < 0) {
+					firstByte = b;
+				} else {
+					PdBase.sendNoteOn(channel, firstByte, 0);
+					firstByte = -1;
+				}
+				break;
+			case NOTE_ON:
+				if (firstByte < 0) {
+					firstByte = b;
+				} else {
+					PdBase.sendNoteOn(channel, firstByte, b);
+					firstByte = -1;
+				}
+				break;
+			case POLY_TOUCH:
+				if (firstByte < 0) {
+					firstByte = b;
+				} else {
+					PdBase.sendPolyAftertouch(channel, firstByte, b);
+					firstByte = -1;
+				}
+				break;
+			case CONTROL_CHANGE:
+				if (firstByte < 0) {
+					firstByte = b;
+				} else {
+					PdBase.sendControlChange(channel, firstByte, b);
+					firstByte = -1;
+				}
+				break;
+			case PROGRAM_CHANGE:
+				PdBase.sendProgramChange(channel, b);
+				break;
+			case AFTERTOUCH:
+				PdBase.sendAftertouch(channel, b);
+				break;
+			case PITCH_BEND:
+				if (firstByte < 0) {
+					firstByte = b;
+				} else {
+					PdBase.sendPitchBend(channel, ((b << 7) | firstByte) - 8192);
+					firstByte = -1;
+				}
+				break;
+				default /* State.NONE */:
+				PdBase.sendMidiByte(0, b);
+				break;
+			}
+		}
 	}
-
-	@Override
-	public void onPolyAftertouch(int channel, int key, int velocity) {
-		PdBase.sendPolyAftertouch(channel, key, velocity);
-	}
-
-	@Override
-	public void onPitchBend(int channel, int value) {
-		PdBase.sendPitchBend(channel, value);
-	}
-
-	@Override
-	public void onNoteOn(int channel, int key, int velocity) {
-		PdBase.sendNoteOn(channel, key, velocity);
-	}
-
-	@Override
-	public void onNoteOff(int channel, int key, int velocity) {
-		PdBase.sendNoteOn(channel, key, 0);
-	}
-
-	@Override
-	public void onControlChange(int channel, int controller, int value) {
-		PdBase.sendControlChange(channel, controller, value);
-	}
-
-	@Override
-	public void onAftertouch(int channel, int velocity) {
-		PdBase.sendAftertouch(channel, velocity);
-	}
-
-	@Override
-	public boolean beginBlock() {
-		return false;
-	}
-
-	@Override
-	public void endBlock() {}
 }

--- a/PdCore/src/main/java/org/puredata/android/midi/MidiToPdAdapter.java
+++ b/PdCore/src/main/java/org/puredata/android/midi/MidiToPdAdapter.java
@@ -17,12 +17,44 @@ import android.media.midi.MidiReceiver;
  * @author Antoine Rousseau (antoine@metalu.net)
  */
 public class MidiToPdAdapter extends MidiReceiver {
+	private final int port;
 	private static enum State {
 		NOTE_OFF, NOTE_ON, POLY_TOUCH, CONTROL_CHANGE, PROGRAM_CHANGE, AFTERTOUCH, PITCH_BEND, NONE
 	}
 	private State midiState = State.NONE;
 	private int channel;
 	private int firstByte;
+
+/**
+ * Create an adapter for a specific port, to connect to a MidiOutputPort
+ * @param port starting at 0; Midi messages sent to Pd will have the channel increased by (16 * port).
+ * <br><br>
+ * Example code:
+ * <pre>{@code 
+MidiManager midiManager = (MidiManager) getSystemService(MIDI_SERVICE);
+final MidiDeviceInfo[] infos = midiManager.getDevices();
+if (infos.length == 0) return;
+final MidiDeviceInfo info = infos[0]; // Select the first available device
+midiManager.openDevice(info, new MidiManager.OnDeviceOpenedListener() {
+	@Override
+	public void onDeviceOpened(MidiDevice device) {
+		if (device == null) return;
+		for (MidiDeviceInfo.PortInfo portInfo : device.getInfo().getPorts()) {
+			if (portInfo.getType() == MidiDeviceInfo.PortInfo.TYPE_OUTPUT) {
+				MidiOutputPort outputPort = device.openOutputPort(portInfo.getPortNumber());
+				if (outputPort != null) {
+					outputPort.connect(new MidiToPdAdapter(0)); // Map the device to Pd Midi port 0 (channel 0-15)
+					break; // Only connect to the first available output port
+				}
+			}
+		}
+	}
+}
+ * }</pre>
+ */
+	public MidiToPdAdapter(int port) {
+		this.port = port;
+	}
 
 	@Override
 	public void onSend(byte[] msg, int offset, int count, long timestamp) {
@@ -33,7 +65,7 @@ public class MidiToPdAdapter extends MidiReceiver {
 		if (b < 0) {
 			midiState = State.values()[(b >> 4) & 0x07];
 			if (midiState != State.NONE) {
-				channel = b & 0x0f;
+				channel = b & 0x0f + 16 * port;
 				firstByte = -1;
 			} else {
 				PdBase.sendMidiByte(0, b);

--- a/PdCore/src/main/java/org/puredata/android/midi/PdToMidiAdapter.java
+++ b/PdCore/src/main/java/org/puredata/android/midi/PdToMidiAdapter.java
@@ -8,70 +8,84 @@
 package org.puredata.android.midi;
 
 import org.puredata.core.PdMidiReceiver;
-
-import com.noisepages.nettoyeur.midi.MidiReceiver;
+import android.media.midi.MidiInputPort;
 
 /**
  * Adapter class for connecting MIDI output from Pd to input for AndroidMidi.
  * 
  * @author Peter Brinkmann (peter.brinkmann@gmail.com)
+ * @author Antoine Rousseau (antoine@metalu.net)
  */
 public class PdToMidiAdapter implements PdMidiReceiver {
+	private final MidiInputPort inputPort;
 
-	private final MidiReceiver receiver;
-	
-	/**
-	 * Constructor. Note that instances of this class still need to be installed with
-	 * PdBase.setMidiReceiver.
-	 * 
-	 * @param receiver to forward MIDI messages to
-	 */
-	public PdToMidiAdapter(MidiReceiver receiver) {
-		this.receiver = receiver;
+	public PdToMidiAdapter(MidiInputPort inputPort) {
+		this.inputPort = inputPort;
 	}
-	
-	@Override
-	public void receiveProgramChange(int channel, int value) {
-		receiver.onProgramChange(channel, value);
-	}
-	
-	@Override
-	public void receivePolyAftertouch(int channel, int pitch, int value) {
-		receiver.onPolyAftertouch(channel, pitch, value);
-	}
-	
-	@Override
-	public void receivePitchBend(int channel, int value) {
-		receiver.onPitchBend(channel, value);
-	}
-	
+
 	@Override
 	public void receiveNoteOn(int channel, int pitch, int velocity) {
-		receiver.onNoteOn(channel, pitch, velocity);
+		write(0x90, channel, pitch, velocity);
 	}
-	
+
 	@Override
-	public void receiveMidiByte(int port, int value) {
-		receiver.onRawByte((byte) value);
+	public void receivePolyAftertouch(int channel, int pitch, int value) {
+		write(0xa0, channel, pitch, value);
 	}
-	
+
 	@Override
 	public void receiveControlChange(int channel, int controller, int value) {
-		receiver.onControlChange(channel, controller, value);
+		write(0xb0, channel, controller, value);
 	}
-	
+
+	@Override
+	public void receiveProgramChange(int channel, int program) {
+		write(0xc0, channel, program);
+	}
+
 	@Override
 	public void receiveAftertouch(int channel, int value) {
-		receiver.onAftertouch(channel, value);
+		write(0xd0, channel, value);
+	}
+
+	@Override
+	public void receivePitchBend(int channel, int value) {
+		value += 8192;
+		write(0xe0, channel, (value & 0x7f), (value >> 7));
+	}
+
+	@Override
+	public void receiveMidiByte(int port, int value) {
+		final byte[] message = {(byte) value};
+		writeMessage(message);
+	}
+
+	private static byte firstByte(int msg, int ch) {
+		return (byte) (msg | (ch & 0x0f));
+	}
+
+	private void write(int msg, int ch, int a) {
+		final byte[] message = {firstByte(msg, ch), (byte) a};
+		writeMessage(message);
+	}
+
+	private void write(int msg, int ch, int a, int b) {
+		final byte[] message = {firstByte(msg, ch), (byte) a, (byte) b};
+		writeMessage(message);
+	}
+
+	private void writeMessage(byte[] message) {
+		try {
+			inputPort.send(message, 0, message.length);
+		} catch(Exception e) {}
 	}
 
 	@Override
 	public boolean beginBlock() {
-		return receiver.beginBlock();
+		return false;
 	}
 
 	@Override
 	public void endBlock() {
-		receiver.endBlock();
 	}
 }

--- a/PdCore/src/main/java/org/puredata/android/midi/PdToMidiAdapter.java
+++ b/PdCore/src/main/java/org/puredata/android/midi/PdToMidiAdapter.java
@@ -9,6 +9,9 @@ package org.puredata.android.midi;
 
 import org.puredata.core.PdMidiReceiver;
 import android.media.midi.MidiInputPort;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Map.Entry;
 
 /**
  * Adapter class for connecting MIDI output from Pd to input for AndroidMidi.
@@ -17,47 +20,112 @@ import android.media.midi.MidiInputPort;
  * @author Antoine Rousseau (antoine@metalu.net)
  */
 public class PdToMidiAdapter implements PdMidiReceiver {
-	private final MidiInputPort inputPort;
+	private Map<Integer, MidiInputPort> inputPorts = new HashMap<Integer, MidiInputPort>();
 
-	public PdToMidiAdapter(MidiInputPort inputPort) {
-		this.inputPort = inputPort;
+/**
+ * Send Midi messages from Pd to a Midi device
+ * @param inputPort input port of the Midi ouput device, as returned by MidiDevice.openInputPort()
+ * @param pdPort starting at 0; Midi messages received from Pd whose channel is between
+ * (16 * pdPort) and (16 * pdPort + 15) will be sent to the device with the channel reduced by (16 * pdPort)
+ * <br><br>
+ * Example code:
+ * <pre>{@code 
+MidiManager midiManager = (MidiManager) getSystemService(MIDI_SERVICE);
+final MidiDeviceInfo[] infos = midiManager.getDevices();
+if (infos.length == 0) return;
+final MidiDeviceInfo info = infos[0]; // Select the first available device
+midiManager.openDevice(info, new MidiManager.OnDeviceOpenedListener() {
+	@Override
+	public void onDeviceOpened(MidiDevice device) {
+		if (device == null) return;
+		for (MidiDeviceInfo.PortInfo portInfo : device.getInfo().getPorts()) {
+			if (portInfo.getType() == MidiDeviceInfo.PortInfo.TYPE_INPUT) {
+				MidiInputPort inputPort = device.openInputPort(portInfo.getPortNumber());
+				if (inputPort != null) {
+					pdToMidiAdapter.open(inputPort, 0); // Map the device to Pd Midi port 0 (channel 0-15)
+					break; // Only connect to the first available input port
+				}
+			}
+		}
+	}
+}
+ * }</pre>
+ */
+	public void open(MidiInputPort inputPort, int pdPort) {
+		close(inputPort);
+		close(pdPort);
+		inputPorts.put(pdPort, inputPort);
 	}
 
+/**
+ * Close the connection to a device port
+ * @param inputPort input port of the Midi ouput device, that needs to be closed
+ */
+	public void close(MidiInputPort inputPort) {
+		if(! inputPorts.containsValue(inputPort)) return;
+		for (Entry<Integer, MidiInputPort> entry : inputPorts.entrySet()) {
+			if (entry.getValue().equals(inputPort)) {
+				close(entry.getKey());
+			}
+		}
+	}
+
+/**
+ * Close the connection from a Pd Midi port
+ * @param pdPort starting at 0; Midi messages coming from Pd for this port will be ignored, and the associated MidiInputPort will be closed
+ */
+	public void close(int pdPort) {
+		MidiInputPort inputPort = inputPorts.get(pdPort);
+		if(inputPort != null) {
+			try {
+				inputPort.close();
+			} catch(Exception e) {}
+			inputPorts.remove(pdPort);
+		}
+	}
+
+/** @hidden to javadoc*/
 	@Override
 	public void receiveNoteOn(int channel, int pitch, int velocity) {
 		write(0x90, channel, pitch, velocity);
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receivePolyAftertouch(int channel, int pitch, int value) {
 		write(0xa0, channel, pitch, value);
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receiveControlChange(int channel, int controller, int value) {
 		write(0xb0, channel, controller, value);
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receiveProgramChange(int channel, int program) {
 		write(0xc0, channel, program);
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receiveAftertouch(int channel, int value) {
 		write(0xd0, channel, value);
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receivePitchBend(int channel, int value) {
 		value += 8192;
 		write(0xe0, channel, (value & 0x7f), (value >> 7));
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void receiveMidiByte(int port, int value) {
 		final byte[] message = {(byte) value};
-		writeMessage(message);
+		writeMessage(port, message);
 	}
 
 	private static byte firstByte(int msg, int ch) {
@@ -66,25 +134,28 @@ public class PdToMidiAdapter implements PdMidiReceiver {
 
 	private void write(int msg, int ch, int a) {
 		final byte[] message = {firstByte(msg, ch), (byte) a};
-		writeMessage(message);
+		writeMessage(ch, message);
 	}
 
 	private void write(int msg, int ch, int a, int b) {
 		final byte[] message = {firstByte(msg, ch), (byte) a, (byte) b};
-		writeMessage(message);
+		writeMessage(ch, message);
 	}
 
-	private void writeMessage(byte[] message) {
-		try {
+	private void writeMessage(int channel, byte[] message) {
+		MidiInputPort inputPort = inputPorts.get(channel / 16);
+		if(inputPort != null) try {
 			inputPort.send(message, 0, message.length);
 		} catch(Exception e) {}
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public boolean beginBlock() {
 		return false;
 	}
 
+/** @hidden to javadoc*/
 	@Override
 	public void endBlock() {
 	}


### PR DESCRIPTION
- Remove com.noisepages.nettoyeur:midi dependency, which 
   - isn't available anymore from maven (the http://noisepages.com site is even zombie)
   - doesn't make use of up-to-date Android Midi API, see https://github.com/nettoyeurny/btmidi/issues/10#issuecomment-3001531039
- Reimplement Midi adapters using Android API, reusing Peter's (from/to)WireConverters coming from: 
https://github.com/nettoyeurny/btmidi/blob/master/AndroidMidi/src/com/noisepages/nettoyeur/midi/