### PR TITLE
fix javadoc generation

### DIFF
--- a/PdCore/src/main/java/org/puredata/android/io/AudioWrapper.java
+++ b/PdCore/src/main/java/org/puredata/android/io/AudioWrapper.java
@@ -9,7 +9,7 @@ package org.puredata.android.io;
 
 import java.io.IOException;
 
-import org.puredata.android.service.R;
+import org.puredata.android.service.*;
 import org.puredata.android.utils.Properties;
 
 import android.annotation.TargetApi;

--- a/PdCore/src/main/java/org/puredata/android/service/PdService.java
+++ b/PdCore/src/main/java/org/puredata/android/service/PdService.java
@@ -25,7 +25,6 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
-import androidx.core.app.NotificationCompat;
 import android.util.Log;
 
 import java.io.File;
@@ -242,7 +241,7 @@ public class PdService extends Service {
 		}
 
 		PendingIntent pi = PendingIntent.getActivity(getApplicationContext(), 0, intent, PendingIntent.FLAG_IMMUTABLE);
-		return new NotificationCompat.Builder(PdService.this, TAG)
+		return new Notification.Builder(PdService.this, TAG)
 				.setSmallIcon(icon)
 				.setContentTitle(title)
 				.setTicker(title)


### PR DESCRIPTION
These small changes clear errors of javadoc task, which then successfully generates the javadoc pages.
