### PR TITLE
clear 'MissingPermission' lint error

### DIFF
--- a/PdCore/AndroidManifest.xml
+++ b/PdCore/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.puredata.android.service" >
+  <uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/PdCore/src/main/java/org/puredata/android/io/AudioRecordWrapper.java
+++ b/PdCore/src/main/java/org/puredata/android/io/AudioRecordWrapper.java
@@ -28,7 +28,7 @@ import android.os.Process;
 public class AudioRecordWrapper {
 
 	private static final int ENCODING = AudioFormat.ENCODING_PCM_16BIT;
-	private final AudioRecord rec;
+	private AudioRecord rec = null;
 	private final int bufSizeShorts;
 	private final BlockingQueue<short[]> queue = new SynchronousQueue<short[]>();
 	private Thread inputThread = null;
@@ -43,14 +43,17 @@ public class AudioRecordWrapper {
 			throw new IOException("bad AudioRecord parameters; sr: " + sampleRate + ", ch: " + inChannels + ", bufSize: " + bufferSizePerChannel);
 		}
 		while (recSizeBytes < minRecSizeBytes) recSizeBytes += bufSizeBytes;
-		rec = new AudioRecord(MediaRecorder.AudioSource.MIC, sampleRate, channelConfig, ENCODING, recSizeBytes);
-		if (rec != null && rec.getState() != AudioRecord.STATE_INITIALIZED) {
-			rec.release();
-			throw new IOException("unable to initialize AudioRecord instance for sr: " + sampleRate + ", ch: " + inChannels + ", bufSize: " + bufferSizePerChannel);
-		}
+		try{
+			rec = new AudioRecord(MediaRecorder.AudioSource.MIC, sampleRate, channelConfig, ENCODING, recSizeBytes);
+			if (rec != null && rec.getState() != AudioRecord.STATE_INITIALIZED) {
+				rec.release();
+				throw new IOException("unable to initialize AudioRecord instance for sr: " + sampleRate + ", ch: " + inChannels + ", bufSize: " + bufferSizePerChannel);
+			}
+		} catch(SecurityException e) {}
 	}
 
 	public synchronized void start() {
+		if (rec == null) return;
 		inputThread = new Thread() {
 			@Override
 			public void run() {
@@ -91,6 +94,7 @@ public class AudioRecordWrapper {
 	}
 
 	public synchronized void release() {
+		if (rec == null) return;
 		stop();
 		rec.release();
 		queue.clear();

--- a/PdCore/src/main/java/org/puredata/android/io/AudioRecordWrapper.java
+++ b/PdCore/src/main/java/org/puredata/android/io/AudioRecordWrapper.java
@@ -45,7 +45,7 @@ public class AudioRecordWrapper {
 		while (recSizeBytes < minRecSizeBytes) recSizeBytes += bufSizeBytes;
 		try{
 			rec = new AudioRecord(MediaRecorder.AudioSource.MIC, sampleRate, channelConfig, ENCODING, recSizeBytes);
-			if (rec != null && rec.getState() != AudioRecord.STATE_INITIALIZED) {
+			if (rec.getState() != AudioRecord.STATE_INITIALIZED) {
 				rec.release();
 				throw new IOException("unable to initialize AudioRecord instance for sr: " + sampleRate + ", ch: " + inChannels + ", bufSize: " + bufferSizePerChannel);
 			}


### PR DESCRIPTION
This clears the following build failure:

``` gradle
> Task :PdCore:lintDebug FAILED
Lint found 1 errors, 8 warnings. First failure:

(...)/AudioRecordWrapper.java:47: Error: Call requires permission which may be rejected by user: code should explicitly check to see if permission is available (with checkPermission) or explicitly handle a potential SecurityException [MissingPermission]
   rec = new AudioRecord(MediaRecorder.AudioSource.MIC, sampleRate, channelConfig, ENCODING, recSizeBytes);
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "MissingPermission":
   This check scans through your code and libraries and looks at the APIs
   being used, and checks this against the set of permissions required to
   access those APIs. If the code using those APIs is called at runtime, then
   the program will crash.

   Furthermore, for permissions that are revocable (with targetSdkVersion 23),
   client code must also be prepared to handle the calls throwing an exception
   if the user rejects the request for permission at runtime.

FAILURE: Build failed with an exception.
```