### PR TITLE
PdCore: add a 'Verbose [on/off]' preference

### DIFF
--- a/PdCore/src/main/java/org/puredata/android/service/PdService.java
+++ b/PdCore/src/main/java/org/puredata/android/service/PdService.java
@@ -143,6 +143,8 @@ public class PdService extends Service {
 		inputChannels = nic;
 		outputChannels = noc;
 		bufferSizeMillis = millis;
+		boolean verbose = prefs.getBoolean(res.getString(R.string.pref_key_verbose), false);
+		PdBase.setVerbose(verbose);
 	}
 
 	/**

--- a/PdCore/src/main/res/values/strings.xml
+++ b/PdCore/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
 	<string name="pref_key_outchannels">OUTPUT_CHANNELS</string>
 	<string name="pref_title_outchannels">Output channels</string>
 	<string name="pref_sum_outchannels">Number of output channels</string>
+	<string name="pref_key_verbose">PD_VERBOSE</string>
+	<string name="pref_title_verbose">Verbose</string>
+	<string name="pref_sum_verbose">Increase Pd loglevel</string>
 </resources>

--- a/PdCore/src/main/res/xml/preferences.xml
+++ b/PdCore/src/main/res/xml/preferences.xml
@@ -11,4 +11,6 @@
 	<ListPreference android:key="@string/pref_key_outchannels"
 		android:entryValues="@array/outchannels_values" android:entries="@array/outchannels_labels"
 		android:title="@string/pref_title_outchannels" android:summary="@string/pref_sum_outchannels"></ListPreference>
+	<SwitchPreference android:key="@string/pref_key_verbose"
+		android:title="@string/pref_title_verbose" android:summary="@string/pref_sum_verbose"></SwitchPreference>
 </PreferenceScreen>


### PR DESCRIPTION
It's quite useful for debugging `PdTest` to have a Verbose switch.
